### PR TITLE
Singleton providers

### DIFF
--- a/src/bootstrap.spec.ts
+++ b/src/bootstrap.spec.ts
@@ -40,7 +40,7 @@ describe('bootstrap', () => {
         .and.returnValue(bootstrapValueRegistrySpy);
 
     bootstrapSourcesSpy = jasmine.createSpy('bootstrapSources');
-    bootstrapValueRegistrySpy.bindSources.and.returnValue(bootstrapSourcesSpy);
+    (bootstrapValueRegistrySpy as any).valueSources = bootstrapSourcesSpy;
 
     bootstrapContextSpy = jasmine.createSpyObj('bootstrapContext', ['get']);
     (bootstrapValueRegistrySpy as any).values = bootstrapContextSpy;

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -50,7 +50,7 @@ function initBootstrap(valueRegistry: BootstrapValueRegistry) {
 
     constructor() {
       super();
-      definitionValueRegistry = DefinitionValueRegistry.create(valueRegistry.bindSources(this));
+      definitionValueRegistry = DefinitionValueRegistry.create(valueRegistry.valueSources);
       componentValueRegistry = ComponentValueRegistry.create();
       elementBuilder = ElementBuilder.create({ definitionValueRegistry, componentValueRegistry });
       componentRegistry = ComponentRegistry.create({ bootstrapContext: this, elementBuilder });

--- a/src/common/context/context-value-registry.spec.ts
+++ b/src/common/context/context-value-registry.spec.ts
@@ -186,9 +186,12 @@ describe('common/context/context-value-registry', () => {
       let values: ContextValues;
 
       beforeEach(() => {
-        values = registry.newValues();
+        values = registry.values;
       });
 
+      it('is singleton instance', () => {
+        expect(registry.values).toBe(values);
+      });
       it('return associated value', () => {
         providerSpy.and.returnValue('value');
 

--- a/src/common/context/context-value-registry.spec.ts
+++ b/src/common/context/context-value-registry.spec.ts
@@ -1,4 +1,4 @@
-import { ContextValueDefaultHandler, MultiValueKey, SingleValueKey } from './context-value';
+import { MultiValueKey, SingleValueKey } from './context-value';
 import { ContextValueRegistry } from './context-value-registry';
 import { ContextValues } from './context-values';
 import Spy = jasmine.Spy;
@@ -8,216 +8,73 @@ describe('common/context/context-value-registry', () => {
 
     const key = new SingleValueKey<string>('test-key');
     let registry: ContextValueRegistry<ContextValues>;
+    let values: ContextValues;
     let providerSpy: Spy;
-    let context: ContextValues;
-    let handleDefault: ContextValueDefaultHandler<any>;
 
     beforeEach(() => {
       registry = new ContextValueRegistry();
+      values = registry.newValues();
       providerSpy = jasmine.createSpy('provider');
       registry.provide(key, providerSpy);
-      context = { name: 'context' } as any;
-      handleDefault = defaultProvider => defaultProvider();
     });
 
-    it('does not provide any value if there is no provider', () => {
-      expect(registry.get(new SingleValueKey(key.name), context, handleDefault)).toBeUndefined();
-    });
-    it('does not provide any value if provider did not provide any value', () => {
-      expect(registry.get(key, context, handleDefault)).toBeUndefined();
-    });
-    it('provides the value', () => {
+    describe('Single value', () => {
+      it('is associated with provided value', () => {
 
-      const value = 'test value';
+        const value = 'test value';
 
-      providerSpy.and.returnValue(value);
+        providerSpy.and.returnValue(value);
 
-      expect(registry.get(key, context, handleDefault)).toBe(value);
-    });
-    it('provides default value if there is no provider', () => {
-
-      const defaultValue = 'default';
-      const keyWithDefaults = new SingleValueKey(key.name, () => defaultValue);
-
-      expect(registry.get(keyWithDefaults, context, handleDefault)).toBe(defaultValue);
-    });
-    it('provides default value if provider did not provide any value', () => {
-
-      const defaultValue = 'default';
-      const keyWithDefaults = new SingleValueKey(key.name, () => defaultValue);
-
-      registry.provide(keyWithDefaults, () => null);
-
-      expect(registry.get(keyWithDefaults, context, handleDefault)).toBe(defaultValue);
-    });
-
-    describe('Providers combination', () => {
-
-      let provider2Spy: Spy;
-
-      beforeEach(() => {
-        provider2Spy = jasmine.createSpy('provider2');
-        registry.provide(key, provider2Spy);
+        expect(values.get(key)).toBe(value);
       });
-
-      it('provides the last constructed value', () => {
-        providerSpy.and.returnValue('value1');
-        provider2Spy.and.returnValue('value2');
-
-        expect(registry.get(key, context, handleDefault)).toBe('value2');
-      });
-      it('provides the first constructed value if the second one is undefined', () => {
-        providerSpy.and.returnValue('value1');
-
-        expect(registry.get(key, context, handleDefault)).toBe('value1');
-      });
-      it('provides the first constructed value if the second one is null', () => {
-        providerSpy.and.returnValue('value1');
-        provider2Spy.and.returnValue(null);
-
-        expect(registry.get(key, context, handleDefault)).toBe('value1');
-      });
-    });
-
-    describe('Chained registry', () => {
-
-      let chained: ContextValueRegistry<ContextValues>;
-      let provider2Spy: Spy;
-
-      beforeEach(() => {
-        chained = new ContextValueRegistry(registry.bindSources(context));
-        provider2Spy = jasmine.createSpy('provider2');
-      });
-
-      it('prefers explicit value', () => {
-
-        const value1 = 'initial value';
-        const value2 = 'actual value';
-
-        providerSpy.and.returnValue(value1);
-
-        chained.provide(key, provider2Spy);
-        provider2Spy.and.returnValue(value2);
-
-        expect(chained.get(key, context, handleDefault)).toBe(value2);
-      });
-      it('falls back to initial value', () => {
-
-        const value1 = 'initial value';
-
-        providerSpy.and.returnValue(value1);
-
-        chained.provide(key, provider2Spy);
-        provider2Spy.and.returnValue(null);
-
-        expect(chained.get(key, context, handleDefault)).toBe(value1);
-      });
-    });
-
-    describe('Multi-value', () => {
-
-      let multiKey: MultiValueKey<string>;
-
-      beforeEach(() => {
-        multiKey = new MultiValueKey('values');
-      });
-
-      it('is associated with empty array by default', () => {
-        expect(registry.get(multiKey, context, handleDefault)).toEqual([]);
-      });
-      it('is associated with empty array if providers did not return any values', () => {
-        registry.provide(multiKey, () => null);
-        registry.provide(multiKey, () => undefined);
-
-        expect(registry.get(multiKey, context, handleDefault)).toEqual([]);
-      });
-      it('is associated with default value if there is no provider', () => {
-
-        const defaultValue = ['default'];
-        const keyWithDefaults = new MultiValueKey('key', () => defaultValue);
-
-        expect(registry.get(keyWithDefaults, context, handleDefault)).toEqual(defaultValue);
-      });
-      it('is associated with default value if providers did not return any values', () => {
-
-        const defaultValue = ['default'];
-        const keyWithDefaults = new MultiValueKey('key', () => defaultValue);
-
-        registry.provide(keyWithDefaults, () => null);
-        registry.provide(keyWithDefaults, () => undefined);
-
-        expect(registry.get(keyWithDefaults, context, handleDefault)).toEqual(defaultValue);
-      });
-      it('is associated with provided values array', () => {
-        registry.provide(multiKey, () => 'a');
-        registry.provide(multiKey, () => undefined);
-        registry.provide(multiKey, () => 'c');
-
-        expect(registry.get(multiKey, context, handleDefault)).toEqual(['a', 'c']);
-      });
-    });
-
-    describe('append', () => {
-
-      let registry2: ContextValueRegistry<ContextValues>;
-      let combined: ContextValueRegistry<ContextValues>;
-
-      beforeEach(() => {
-        registry2 = new ContextValueRegistry();
-        combined = registry.append(registry2);
-      });
-
-      it('contains all sources', () => {
-        providerSpy.and.returnValue('1');
-        registry2.provide(key, () => '2');
-        registry2.provide(key, () => '3');
-        expect([...combined.sources(context, key)]).toEqual(['1', '2', '3']);
-      });
-      it('contains reverted sources', () => {
-        providerSpy.and.returnValue('1');
-        registry2.provide(key, () => '2');
-        registry2.provide(key, () => '3');
-        expect([...combined.sources(context, key).reverse()]).toEqual(['3', '2', '1']);
-      });
-    });
-
-    describe('Values', () => {
-
-      let values: ContextValues;
-
-      beforeEach(() => {
-        values = registry.newValues();
-      });
-
-      it('return associated value', () => {
-        providerSpy.and.returnValue('value');
-
-        expect(values.get(key)).toBe('value');
-      });
-      it('throw if there is no default value', () => {
+      it('throws if there is no default value', () => {
         expect(() => values.get(new SingleValueKey(key.name))).toThrowError();
       });
-      it('return default value is there is no value', () => {
+      it('provides default value is there is no provider', () => {
         expect(values.get(new SingleValueKey<string>(key.name), 'default')).toBe('default');
       });
-      it('return key default value is there is no value', () => {
+      it('provides default value if provider did not provide any value', () => {
+
+        const defaultValue = 'default';
+        const keyWithDefaults = new SingleValueKey(key.name, () => defaultValue);
+
+        registry.provide(keyWithDefaults, () => null);
+
+        expect(values.get(keyWithDefaults)).toBe(defaultValue);
+      });
+      it('is associated with default value is there is no provider', () => {
         expect(values.get(new SingleValueKey<string>(key.name, () => 'default'))).toBe('default');
       });
-      it('prefer explicit default value over key one', () => {
+      it('prefers explicit default value over key one', () => {
         expect(values.get(new SingleValueKey<string>(key.name, () => 'key default'), 'explicit default'))
             .toBe('explicit default');
       });
-      it('prefer explicit `null` default value over key one', () => {
+      it('prefers explicit `null` default value over key one', () => {
         expect(values.get(new SingleValueKey<string>(key.name, () => 'default'), null))
             .toBeNull();
       });
-      it('prefer explicit `undefined` default value over key one', () => {
+      it('prefers explicit `undefined` default value over key one', () => {
         expect(values.get(new SingleValueKey<string>(key.name, () => 'default'), undefined))
             .toBeUndefined();
+      });
+      it('caches value sources', () => {
+
+        const value = 'test value';
+
+        providerSpy.and.returnValue(value);
+
+        expect([...values.get(key.sourcesKey)]).toEqual([value]);
+        expect(values.get(key)).toBe(value);
+
+        providerSpy.and.returnValue('other');
+
+        expect([...values.get(key.sourcesKey)]).toEqual([value]);
+        expect(values.get(key)).toBe(value);
       });
       it('caches the value', () => {
 
         const value = 'value';
+
         providerSpy.and.returnValue(value);
 
         expect(values.get(key)).toBe(value);
@@ -243,46 +100,172 @@ describe('common/context/context-value-registry', () => {
         expect(values.get(key, value1)).toBe(value1);
         expect(values.get(key, value2)).toBe(value2);
       });
+    });
 
-      describe('on multi-value', () => {
+    describe('Multi-value', () => {
 
-        const mvKey = new MultiValueKey<string>('test-mv-key');
+      let multiKey: MultiValueKey<string>;
 
-        beforeEach(() => {
-          providerSpy = jasmine.createSpy('mvProvider');
-          registry.provide(mvKey, providerSpy);
-        });
+      beforeEach(() => {
+        multiKey = new MultiValueKey('values');
+      });
 
-        it('return associated value', () => {
-          providerSpy.and.returnValue('value');
+      it('is associated with empty array by default', () => {
+        expect(values.get(multiKey)).toEqual([]);
+      });
+      it('is associated with empty array if providers did not return any values', () => {
+        registry.provide(multiKey, () => null);
+        registry.provide(multiKey, () => undefined);
 
-          expect(values.get(mvKey)).toEqual(['value']);
-        });
-        it('throw if there is no default value', () => {
-          expect(() => values.get(new MultiValueKey(mvKey.name, () => null))).toThrowError();
-        });
-        it('return empty array by default', () => {
-          expect(values.get(new MultiValueKey(mvKey.name))).toEqual([]);
-        });
-        it('return default value is there is no value', () => {
-          expect(values.get(new MultiValueKey<string>(mvKey.name), ['default'])).toEqual(['default']);
-        });
-        it('return key default value is there is no value', () => {
-          expect(values.get(new MultiValueKey<string>(mvKey.name, () => ['default']))).toEqual(['default']);
-        });
-        it('prefer explicit default value over key one', () => {
-          expect(values.get(new MultiValueKey<string>(mvKey.name, () => ['key', 'default']), ['explicit', 'default']))
-              .toEqual(['explicit', 'default']);
-        });
-        it('prefer explicit `null` default value over key one', () => {
-          expect(values.get(new MultiValueKey<string>(mvKey.name, () => ['key', 'default']), null))
-              .toBeNull();
-        });
-        it('prefer explicit `undefined` default value over key one', () => {
-          expect(values.get(new MultiValueKey<string>(mvKey.name, () => ['key', 'default']), undefined))
-              .toBeUndefined();
-        });
+        expect(values.get(multiKey)).toEqual([]);
+      });
+      it('is associated with default value if there is no provider', () => {
+
+        const defaultValue = ['default'];
+        const keyWithDefaults = new MultiValueKey('key', () => defaultValue);
+
+        expect(values.get(keyWithDefaults)).toEqual(defaultValue);
+      });
+      it('is associated with default value if providers did not return any values', () => {
+
+        const defaultValue = ['default'];
+        const keyWithDefaults = new MultiValueKey('key', () => defaultValue);
+
+        registry.provide(keyWithDefaults, () => null);
+        registry.provide(keyWithDefaults, () => undefined);
+
+        expect(values.get(keyWithDefaults)).toEqual(defaultValue);
+      });
+      it('is associated with provided values array', () => {
+        registry.provide(multiKey, () => 'a');
+        registry.provide(multiKey, () => undefined);
+        registry.provide(multiKey, () => 'c');
+
+        expect(values.get(multiKey)).toEqual(['a', 'c']);
+      });
+      it('is associated with value', () => {
+        registry.provide(multiKey, () => 'value');
+
+        expect(values.get(multiKey)).toEqual(['value']);
+      });
+      it('throws if there is no default value', () => {
+        expect(() => values.get(new MultiValueKey(multiKey.name, () => null))).toThrowError();
+      });
+      it('is associated with empty array by default', () => {
+        expect(values.get(new MultiValueKey(multiKey.name))).toEqual([]);
+      });
+      it('is associated with default value is there is no value', () => {
+        expect(values.get(new MultiValueKey<string>(multiKey.name), ['default'])).toEqual(['default']);
+      });
+      it('is associated with key default value is there is no value', () => {
+        expect(values.get(new MultiValueKey<string>(multiKey.name, () => ['default']))).toEqual(['default']);
+      });
+      it('prefers explicit default value over key one', () => {
+        expect(values.get(new MultiValueKey<string>(multiKey.name, () => ['key', 'default']), ['explicit', 'default']))
+            .toEqual(['explicit', 'default']);
+      });
+      it('prefers explicit `null` default value over key one', () => {
+        expect(values.get(new MultiValueKey<string>(multiKey.name, () => ['key', 'default']), null))
+            .toBeNull();
+      });
+      it('prefers explicit `undefined` default value over key one', () => {
+        expect(values.get(new MultiValueKey<string>(multiKey.name, () => ['key', 'default']), undefined))
+            .toBeUndefined();
       });
     });
+
+    describe('Providers combination', () => {
+
+      let provider2Spy: Spy;
+
+      beforeEach(() => {
+        provider2Spy = jasmine.createSpy('provider2');
+        registry.provide(key, provider2Spy);
+      });
+
+      it('provides the last constructed value', () => {
+        providerSpy.and.returnValue('value1');
+        provider2Spy.and.returnValue('value2');
+
+        expect(values.get(key)).toBe('value2');
+      });
+      it('provides the first constructed value if the second one is undefined', () => {
+        providerSpy.and.returnValue('value1');
+
+        expect(values.get(key)).toBe('value1');
+      });
+      it('provides the first constructed value if the second one is null', () => {
+        providerSpy.and.returnValue('value1');
+        provider2Spy.and.returnValue(null);
+
+        expect(values.get(key)).toBe('value1');
+      });
+    });
+
+    describe('Chained registry', () => {
+
+      let chained: ContextValueRegistry<ContextValues>;
+      let chainedValues: ContextValues;
+      let provider2Spy: Spy;
+      let context: ContextValues;
+
+      beforeEach(() => {
+        context = { name: 'context' } as any;
+        chained = new ContextValueRegistry(registry.bindSources(context));
+        chainedValues = chained.newValues();
+        provider2Spy = jasmine.createSpy('provider2');
+      });
+
+      it('prefers explicit value', () => {
+
+        const value1 = 'initial value';
+        const value2 = 'actual value';
+
+        providerSpy.and.returnValue(value1);
+
+        chained.provide(key, provider2Spy);
+        provider2Spy.and.returnValue(value2);
+
+        expect(chainedValues.get(key)).toBe(value2);
+      });
+      it('falls back to initial value', () => {
+
+        const value1 = 'initial value';
+
+        providerSpy.and.returnValue(value1);
+
+        chained.provide(key, provider2Spy);
+        provider2Spy.and.returnValue(null);
+
+        expect(chainedValues.get(key)).toBe(value1);
+      });
+    });
+
+    describe('append', () => {
+
+      let registry2: ContextValueRegistry<ContextValues>;
+      let combined: ContextValueRegistry<ContextValues>;
+      let context: ContextValues;
+
+      beforeEach(() => {
+        registry2 = new ContextValueRegistry();
+        combined = registry.append(registry2);
+        context = { name: 'context' } as any;
+      });
+
+      it('contains all sources', () => {
+        providerSpy.and.returnValue('1');
+        registry2.provide(key, () => '2');
+        registry2.provide(key, () => '3');
+        expect([...combined.sources(context, key)]).toEqual(['1', '2', '3']);
+      });
+      it('contains reverted sources', () => {
+        providerSpy.and.returnValue('1');
+        registry2.provide(key, () => '2');
+        registry2.provide(key, () => '3');
+        expect([...combined.sources(context, key).reverse()]).toEqual(['3', '2', '1']);
+      });
+    });
+
   });
 });

--- a/src/common/context/context-value-registry.spec.ts
+++ b/src/common/context/context-value-registry.spec.ts
@@ -186,12 +186,9 @@ describe('common/context/context-value-registry', () => {
       let values: ContextValues;
 
       beforeEach(() => {
-        values = registry.values;
+        values = registry.newValues();
       });
 
-      it('is singleton instance', () => {
-        expect(registry.values).toBe(values);
-      });
       it('return associated value', () => {
         providerSpy.and.returnValue('value');
 

--- a/src/common/context/context-value-registry.ts
+++ b/src/common/context/context-value-registry.ts
@@ -11,6 +11,7 @@ export class ContextValueRegistry<C extends ContextValues> {
 
   private readonly _providers = new Map<ContextValueKey<any>, ContextValueProvider<C, any>[]>();
   private readonly _initial: ContextValueSource<C>;
+  private _values?: ContextValues & ThisType<C>;
 
   /**
    * Constructs a registry for context value providers.
@@ -96,12 +97,14 @@ export class ContextValueRegistry<C extends ContextValues> {
   }
 
   /**
-   * Creates new context values instance consulting this registry for value providers.
+   * Context values instance consulting this registry for value providers.
    *
-   * @returns New context values instance which methods treat `this` instance as target context the values
-   * provided for.
+   * Treats `this` instance as target context the values provided for.
    */
-  newValues(): ContextValues & ThisType<C> {
+  get values(): ContextValues & ThisType<C> {
+    if (this._values) {
+      return this._values;
+    }
 
     const values = new Map<ContextValueKey<any>, any>();
     const providerRegistry = this;
@@ -144,7 +147,7 @@ export class ContextValueRegistry<C extends ContextValues> {
 
     }
 
-    return new Values();
+    return this._values = new Values();
   }
 
   /**

--- a/src/common/context/context-value-registry.ts
+++ b/src/common/context/context-value-registry.ts
@@ -11,7 +11,6 @@ export class ContextValueRegistry<C extends ContextValues> {
 
   private readonly _providers = new Map<ContextValueKey<any>, ContextValueProvider<C, any>[]>();
   private readonly _initial: ContextValueSource<C>;
-  private _values?: ContextValues & ThisType<C>;
 
   /**
    * Constructs a registry for context value providers.
@@ -97,14 +96,12 @@ export class ContextValueRegistry<C extends ContextValues> {
   }
 
   /**
-   * Context values instance consulting this registry for value providers.
+   * Creates new context values instance consulting this registry for value providers.
    *
-   * Treats `this` instance as target context the values provided for.
+   * @returns New context values instance which methods treat `this` instance as target context the values
+   * provided for.
    */
-  get values(): ContextValues & ThisType<C> {
-    if (this._values) {
-      return this._values;
-    }
+  newValues(): ContextValues & ThisType<C> {
 
     const values = new Map<ContextValueKey<any>, any>();
     const providerRegistry = this;
@@ -147,7 +144,7 @@ export class ContextValueRegistry<C extends ContextValues> {
 
     }
 
-    return this._values = new Values();
+    return new Values();
   }
 
   /**

--- a/src/common/context/context-value-registry.ts
+++ b/src/common/context/context-value-registry.ts
@@ -1,5 +1,11 @@
 import { RevertibleIterable } from '../iteration';
-import { ContextValueDefaultHandler, ContextValueKey, ContextValueProvider, ContextValueSource } from './context-value';
+import {
+  ContextValueDefaultHandler,
+  ContextValueKey,
+  ContextValueProvider,
+  ContextValueSource,
+  ContextValueSourcesKey,
+} from './context-value';
 import { ContextValues } from './context-values';
 
 /**
@@ -9,8 +15,9 @@ import { ContextValues } from './context-values';
  */
 export class ContextValueRegistry<C extends ContextValues> {
 
-  private readonly _providers = new Map<ContextValueKey<any>, ContextValueProvider<C, any>[]>();
   private readonly _initial: ContextValueSource<C>;
+  private readonly _providers = new Map<ContextValueSourcesKey<any>, ContextValueProvider<C, any>[]>();
+  private _nonCachedValues?: ContextValues;
 
   /**
    * Constructs a registry for context value providers.
@@ -31,30 +38,15 @@ export class ContextValueRegistry<C extends ContextValues> {
    */
   provide<S>(key: ContextValueKey<any, S>, provider: ContextValueProvider<C, S>): void {
 
-    let providers: ContextValueProvider<C, S>[] | undefined = this._providers.get(key);
+    const sourcesKey = key.sourcesKey;
+    let providers: ContextValueProvider<C, S>[] | undefined = this._providers.get(sourcesKey);
 
     if (providers == null) {
       providers = [provider];
-      this._providers.set(key, providers);
+      this._providers.set(sourcesKey, providers);
     } else {
       providers.push(provider);
     }
-  }
-
-  /**
-   * Returns the value provided for the given key.
-   *
-   * @param key Context value key.
-   * @param context Context to provide value for.
-   * @param handleDefault Default value handler.
-   *
-   * @returns Either constructed value, or `null`/`undefined` if the value can not be constructed.
-   */
-  get<V, S>(
-      key: ContextValueKey<V, S>,
-      context: C,
-      handleDefault: ContextValueDefaultHandler<V>): V | null | undefined {
-    return key.merge(context, this.sources(context, key), handleDefault);
   }
 
   /**
@@ -66,54 +58,80 @@ export class ContextValueRegistry<C extends ContextValues> {
    * @returns A revertible iterable of the value sources associated with the given key.
    */
   sources<V, S>(context: C, key: ContextValueKey<V, S>): RevertibleIterable<S> {
-    return this.bindSources(context)(key);
+    return this.bindSources(context, false)(key);
   }
 
   /**
    * Binds value sources to the given context.
    *
    * @param context Target value context.
+   * @param cache Whether to cache context values. When `false` the value providers may be called multiple times.
    *
    * @returns A provider of context value sources bound to the given context.
    */
-  bindSources(context: C): <V, S>(this: void, key: ContextValueKey<V, S>) => RevertibleIterable<S> {
-    return <V, S>(key: ContextValueKey<V, S>) => {
+  bindSources(context: C, cache?: boolean): <V, S>(this: void, key: ContextValueKey<V, S>) => RevertibleIterable<S> {
 
-      const sources = this._initial(key, context);
-      const providers: ContextValueProvider<C, S>[] = this._providers.get(key) || [];
+    const values = this.newValues(cache);
 
-      return {
-        [Symbol.iterator]: function* () {
-          yield* sources;
-          yield* valueSources(context, providers);
-        },
-        reverse: function* () {
-          yield* valueSources(context, providers.reverse());
-          yield* sources.reverse();
-        },
-      };
-    };
+    return <V, S>(key: ContextValueKey<V, S>) => values.get.call(context, key.sourcesKey);
   }
 
   /**
    * Creates new context values instance consulting this registry for value providers.
    *
+   * @param cache Whether to cache context values. When `false` the value providers may be called multiple times.
+   *
    * @returns New context values instance which methods treat `this` instance as target context the values
    * provided for.
    */
-  newValues(): ContextValues & ThisType<C> {
+  newValues(cache = true): ContextValues & ThisType<C> {
+    if (!cache && this._nonCachedValues) {
+      return this._nonCachedValues;
+    }
 
     const values = new Map<ContextValueKey<any>, any>();
-    const providerRegistry = this;
+    const registry = this;
+
+    function sourcesProvidersFor<V, S>(key: ContextValueSourcesKey<S>): SourceProvider<C, S>[] {
+
+      const providers: ContextValueProvider<C, S>[] = registry._providers.get(key) || [];
+
+      return providers.map(provider => [provider] as SourceProvider<C, S>);
+    }
 
     class Values implements ContextValues {
 
       get<V, S>(this: C, key: ContextValueKey<V, S>, defaultValue?: V | null | undefined): V | null | undefined {
 
+        const context = this;
         const cached: V | undefined = values.get(key);
 
         if (cached != null) {
           return cached;
+        }
+
+        let sourceValues: RevertibleIterable<S>;
+
+        if (key.sourcesKey !== key as any) {
+          // This is not a sources key
+          // Retrieve the sources by sources key
+          sourceValues = context.get(key.sourcesKey);
+        } else {
+          // This is a sources key.
+          // Find providers.
+          const sourceProviders = sourcesProvidersFor(key.sourcesKey);
+          const initial = registry._initial(key, context);
+
+          sourceValues = {
+            [Symbol.iterator]: function* () {
+              yield* initial;
+              yield* valueSources(context, sourceProviders);
+            },
+            reverse: function* () {
+              yield* valueSources(context, sourceProviders.reverse());
+              yield* initial.reverse();
+            },
+          };
         }
 
         let defaultUsed = false;
@@ -133,15 +151,19 @@ export class ContextValueRegistry<C extends ContextValues> {
                   return providedDefault;
                 };
 
-        const constructed = providerRegistry.get(key, this, handleDefault);
+        const constructed = key.merge(context, sourceValues, handleDefault);
 
-        if (!defaultUsed) {
+        if (cache && !defaultUsed) {
           values.set(key, constructed);
         }
 
         return constructed;
       }
 
+    }
+
+    if (!cache) {
+      return this._nonCachedValues = new Values();
     }
 
     return new Values();
@@ -178,12 +200,22 @@ export class ContextValueRegistry<C extends ContextValues> {
 
 }
 
+// Context value provider and cached context value source.
+type SourceProvider<C extends ContextValues, S> = [ContextValueProvider<C, S>, (S | null | undefined)?];
+
 function* valueSources<C extends ContextValues, S>(
     context: C,
-    providers: Iterable<ContextValueProvider<C, S>>): Iterable<S> {
-  for (const provider of providers) {
+    sourceProviders: Iterable<SourceProvider<C, S>>): Iterable<S> {
+  for (const sourceProvider of sourceProviders) {
 
-    const sourceValue = provider(context);
+    let sourceValue: S | null | undefined;
+
+    if (sourceProvider.length > 1) {
+      sourceValue = sourceProvider[1];
+    } else {
+      sourceValue = sourceProvider[0](context);
+      sourceProvider.push(sourceValue);
+    }
 
     if (sourceValue != null) {
       yield sourceValue;

--- a/src/component/definition/element-builder.ts
+++ b/src/component/definition/element-builder.ts
@@ -40,7 +40,6 @@ export class ElementBuilder {
     const def = ComponentDef.of(componentType);
     const builder = this;
     const onComponent = new EventEmitter<ComponentListener>();
-    let values!: ContextValues;
     let typeValueRegistry!: ComponentValueRegistry;
     let whenReady: (this: ElementDefinitionContext, elementType: Class) => void = noop;
 
@@ -53,8 +52,7 @@ export class ElementBuilder {
       constructor() {
         super();
         typeValueRegistry = ComponentValueRegistry.create(builder.definitionValueRegistry.bindSources(this));
-        values = typeValueRegistry.newValues();
-        this.get = values.get;
+        this.get = typeValueRegistry.values.get;
       }
 
       get elementType(): Class {
@@ -137,7 +135,6 @@ export class ElementBuilder {
         const element = this;
         // @ts-ignore
         const elementSuper = (name: string) => super[name] as any;
-        const values = valueRegistry.newValues();
         let whenReady: (this: ElementContext, component: T) => void = noop;
         const connectEvents = new EventEmitter<(this: ElementContext) => void>();
         const disconnectEvents = new EventEmitter<(this: ElementContext) => void>();
@@ -146,7 +143,7 @@ export class ElementBuilder {
 
           readonly element = element;
           readonly elementSuper = elementSuper;
-          readonly get = values.get;
+          readonly get = valueRegistry.values.get;
           readonly onConnect = connectEvents.on;
           readonly onDisconnect = disconnectEvents.on;
 

--- a/src/component/definition/element-builder.ts
+++ b/src/component/definition/element-builder.ts
@@ -40,6 +40,7 @@ export class ElementBuilder {
     const def = ComponentDef.of(componentType);
     const builder = this;
     const onComponent = new EventEmitter<ComponentListener>();
+    let values!: ContextValues;
     let typeValueRegistry!: ComponentValueRegistry;
     let whenReady: (this: ElementDefinitionContext, elementType: Class) => void = noop;
 
@@ -52,7 +53,8 @@ export class ElementBuilder {
       constructor() {
         super();
         typeValueRegistry = ComponentValueRegistry.create(builder.definitionValueRegistry.bindSources(this));
-        this.get = typeValueRegistry.values.get;
+        values = typeValueRegistry.newValues();
+        this.get = values.get;
       }
 
       get elementType(): Class {
@@ -135,6 +137,7 @@ export class ElementBuilder {
         const element = this;
         // @ts-ignore
         const elementSuper = (name: string) => super[name] as any;
+        const values = valueRegistry.newValues();
         let whenReady: (this: ElementContext, component: T) => void = noop;
         const connectEvents = new EventEmitter<(this: ElementContext) => void>();
         const disconnectEvents = new EventEmitter<(this: ElementContext) => void>();
@@ -143,7 +146,7 @@ export class ElementBuilder {
 
           readonly element = element;
           readonly elementSuper = elementSuper;
-          readonly get = valueRegistry.values.get;
+          readonly get = values.get;
           readonly onConnect = connectEvents.on;
           readonly onDisconnect = disconnectEvents.on;
 

--- a/src/component/definition/element-builder.ts
+++ b/src/component/definition/element-builder.ts
@@ -1,4 +1,4 @@
-import { Class, ContextValueKey, ContextValues, EventEmitter, mergeFunctions, noop } from '../../common';
+import { Class, ContextValueKey, EventEmitter, mergeFunctions, noop } from '../../common';
 import { Component, ComponentClass } from '../component';
 import { ComponentContext, ComponentListener, ComponentValueProvider } from '../component-context';
 import { ComponentDef } from '../component-def';
@@ -11,8 +11,8 @@ import { DefinitionValueRegistry } from './definition-value-registry';
  */
 export class ElementBuilder {
 
-  readonly definitionValueRegistry: DefinitionValueRegistry;
-  readonly componentValueRegistry: ComponentValueRegistry;
+  private readonly _definitionValueRegistry: DefinitionValueRegistry;
+  private readonly _componentValueRegistry: ComponentValueRegistry;
   readonly definitions = new EventEmitter<DefinitionListener>();
   readonly components = new EventEmitter<ComponentListener>();
 
@@ -31,8 +31,8 @@ export class ElementBuilder {
         definitionValueRegistry: DefinitionValueRegistry;
         componentValueRegistry: ComponentValueRegistry;
       }) {
-    this.definitionValueRegistry = definitionValueRegistry;
-    this.componentValueRegistry = componentValueRegistry;
+    this._definitionValueRegistry = definitionValueRegistry;
+    this._componentValueRegistry = componentValueRegistry;
   }
 
   buildElement<T extends object>(componentType: ComponentClass<T>): Class {
@@ -40,7 +40,6 @@ export class ElementBuilder {
     const def = ComponentDef.of(componentType);
     const builder = this;
     const onComponent = new EventEmitter<ComponentListener>();
-    let values!: ContextValues;
     let typeValueRegistry!: ComponentValueRegistry;
     let whenReady: (this: ElementDefinitionContext, elementType: Class) => void = noop;
 
@@ -52,8 +51,10 @@ export class ElementBuilder {
 
       constructor() {
         super();
-        typeValueRegistry = ComponentValueRegistry.create(builder.definitionValueRegistry.bindSources(this));
-        values = typeValueRegistry.newValues();
+        typeValueRegistry = ComponentValueRegistry.create(builder._definitionValueRegistry.bindSources(this));
+
+        const values = typeValueRegistry.newValues();
+
         this.get = values.get;
       }
 
@@ -82,7 +83,7 @@ export class ElementBuilder {
         def,
         context,
         onComponent,
-        this.componentValueRegistry.append(typeValueRegistry));
+        this._componentValueRegistry.append(typeValueRegistry));
 
     Object.defineProperty(context, 'elementType', {
       configurable: true,

--- a/src/feature/bootstrap-value-registry.ts
+++ b/src/feature/bootstrap-value-registry.ts
@@ -1,4 +1,4 @@
-import { ContextValueRegistry } from '../common';
+import { ContextValueRegistry, ContextValues } from '../common';
 import { BootstrapContext } from './bootstrap-context';
 
 /**
@@ -6,12 +6,15 @@ import { BootstrapContext } from './bootstrap-context';
  */
 export class BootstrapValueRegistry extends ContextValueRegistry<BootstrapContext> {
 
+  readonly values: ContextValues;
+
   static create(): BootstrapValueRegistry {
     return new BootstrapValueRegistry();
   }
 
   private constructor() {
     super();
+    this.values = this.newValues();
   }
 
 }

--- a/src/feature/bootstrap-value-registry.ts
+++ b/src/feature/bootstrap-value-registry.ts
@@ -1,4 +1,4 @@
-import { ContextValueRegistry, ContextValues } from '../common';
+import { ContextValueRegistry } from '../common';
 import { BootstrapContext } from './bootstrap-context';
 
 /**
@@ -6,15 +6,12 @@ import { BootstrapContext } from './bootstrap-context';
  */
 export class BootstrapValueRegistry extends ContextValueRegistry<BootstrapContext> {
 
-  readonly values: ContextValues;
-
   static create(): BootstrapValueRegistry {
     return new BootstrapValueRegistry();
   }
 
   private constructor() {
     super();
-    this.values = this.newValues();
   }
 
 }

--- a/src/feature/bootstrap-value-registry.ts
+++ b/src/feature/bootstrap-value-registry.ts
@@ -1,4 +1,4 @@
-import { ContextValueRegistry, ContextValues } from '../common';
+import { ContextValueKey, ContextValueRegistry, ContextValues, RevertibleIterable } from '../common';
 import { BootstrapContext } from './bootstrap-context';
 
 /**
@@ -7,6 +7,7 @@ import { BootstrapContext } from './bootstrap-context';
 export class BootstrapValueRegistry extends ContextValueRegistry<BootstrapContext> {
 
   readonly values: ContextValues;
+  readonly valueSources: <V, S>(this: void, key: ContextValueKey<V, S>) => RevertibleIterable<S>;
 
   static create(): BootstrapValueRegistry {
     return new BootstrapValueRegistry();
@@ -15,6 +16,7 @@ export class BootstrapValueRegistry extends ContextValueRegistry<BootstrapContex
   private constructor() {
     super();
     this.values = this.newValues();
+    this.valueSources = <V, S>(key: ContextValueKey<V, S>) => this.values.get.call(this.values, key.sourcesKey);
   }
 
 }


### PR DESCRIPTION
- Introduce `ContextValueKey.sourcesKey`. The value sources are available
under this key now. This makes it possible to base multiple context
values on the same set of sources. I.e. by making their keys to have
the same sources key.
- Ensure that context value providers are called at most once per context
instance. Even when combining multiple context value registries.