### PR TITLE
Context value requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ export class MyComponent {
   private readonly _service: MyService;
   
   constructor(context: ComponentContext) {
-    this._service = context.get(MyService.key); // Obtain a `MyService` instance provided by some feature elsewhere.
+    this._service = context.get(MyService); // Obtain a `MyService` instance provided by some feature elsewhere.
   }
 
 }
@@ -161,14 +161,14 @@ import { BootstrapContext, ComponentContext, DefinitionContext, WesFeature } fro
     MyComponent, // The required component will be defined too.  
   ], 
   prebootstrap: [
-    { key: GlobalService.key, provide: () => new GlobalService() }, // Provide a `GlobalService` available globally
+    { key: GlobalService, provide: () => new GlobalService() }, // Provide a `GlobalService` available globally
                                                                     // in all IoC contexts
   ],
   bootstrap(context: BootstrapContext) {
     // Bootstrap the feature by calling methods of provided context.
 
     context.forDefinitions(
-        DefinitionService.key,
+        DefinitionService,
         (definitionContext: DefinitionContext) => {
           // Provide a `DefinitionService` available during component definition.
           // Such service will be provided per component class
@@ -180,7 +180,7 @@ import { BootstrapContext, ComponentContext, DefinitionContext, WesFeature } fro
       // Notified on each component definition.
 
       // The service provided with `forDefinitions()` method above is available here      
-      const definitionService = definitionContext.get(DefinitionService.key);
+      const definitionService = definitionContext.get(DefinitionService);
       
       definitionContext.whenReady(() => {
         // This is called when element class is defined.
@@ -199,7 +199,7 @@ import { BootstrapContext, ComponentContext, DefinitionContext, WesFeature } fro
       // Notified on each component instantiation.
       
       // The service provided with `forComponents()` method above is available here      
-      const myService = componentContext.get(MyService.key);
+      const myService = componentContext.get(MyService);
       
       componentContext.whenReady(() => {
         // This is called when component is instantiated,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^5.0.4",
-    "@types/jasmine": "^2.8.8",
+    "@types/jasmine": "^2.8.9",
     "codecov": "^3.1.0",
     "fs-extra": "^7.0.0",
     "jasmine": "^3.2.0",
@@ -37,16 +37,16 @@
     "karma-jasmine-html-reporter": "^1.3.1",
     "karma-junit-reporter": "^1.2.0",
     "karma-typescript": "^3.0.13",
-    "puppeteer": "^1.8.0",
-    "rollup": "^0.66.2",
-    "rollup-plugin-commonjs": "^9.1.8",
+    "puppeteer": "^1.9.0",
+    "rollup": "^0.66.5",
+    "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^3.0.0",
-    "rollup-plugin-typescript2": "^0.17.0",
+    "rollup-plugin-typescript2": "^0.17.1",
     "rollup-plugin-uglify": "^6.0.0",
     "tslint": "^5.11.0",
-    "typescript": "^3.1.1"
+    "typescript": "^3.1.2"
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.js",

--- a/src/bootstrap.spec.ts
+++ b/src/bootstrap.spec.ts
@@ -185,21 +185,21 @@ describe('bootstrap', () => {
       });
       it('proxies forDefinitions() method', () => {
 
-        const key = new SingleValueKey<string>('test-value-key');
+        const provide = new SingleValueKey<string>('test-value-key');
         const provider = () => 'test-value';
 
-        featureContext.forDefinitions(key, provider);
+        featureContext.forDefinitions({ provide, provider });
 
-        expect(definitionValueRegistrySpy.provide).toHaveBeenCalledWith(key, provider);
+        expect(definitionValueRegistrySpy.provide).toHaveBeenCalledWith({ provide, provider });
       });
       it('proxies forComponents() method', () => {
 
-        const key = new SingleValueKey<string>('test-value-key');
+        const provide = new SingleValueKey<string>('test-value-key');
         const provider = () => 'test-value';
 
-        featureContext.forComponents(key, provider);
+        featureContext.forComponents({ provide, provider });
 
-        expect(componentValueRegistrySpy.provide).toHaveBeenCalledWith(key, provider);
+        expect(componentValueRegistrySpy.provide).toHaveBeenCalledWith({ provide, provider });
       });
       it('proxies onDefinition() method', () => {
         expect(featureContext.onDefinition).toBe(elementBuilderSpy.definitions.on);

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -10,7 +10,7 @@ import { ComponentRegistry } from './component/definition/component-registry';
 import { ComponentValueRegistry } from './component/definition/component-value-registry';
 import { DefinitionValueRegistry } from './component/definition/definition-value-registry';
 import { ElementBuilder } from './component/definition/element-builder';
-import { BootstrapContext } from './feature';
+import { BootstrapContext as BootstrapContext_ } from './feature';
 import { BootstrapValueRegistry } from './feature/bootstrap-value-registry';
 import { FeatureRegistry } from './feature/feature-registry';
 
@@ -42,7 +42,7 @@ function initBootstrap(valueRegistry: BootstrapValueRegistry) {
   let elementBuilder: ElementBuilder;
   let componentRegistry: ComponentRegistry;
 
-  class Context extends BootstrapContext {
+  class BootstrapContext extends BootstrapContext_ {
 
     readonly onDefinition: EventProducer<DefinitionListener>;
     readonly onComponent: EventProducer<ComponentListener>;
@@ -76,7 +76,7 @@ function initBootstrap(valueRegistry: BootstrapValueRegistry) {
 
   }
 
-  const bootstrapContext = new Context();
+  const bootstrapContext = new BootstrapContext();
 
   return {
     // @ts-ignore

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,10 +1,10 @@
-import { Class, ContextValueKey, EventProducer } from './common';
+import { Class, ContextValueSpec, EventProducer } from './common';
 import {
   ComponentClass,
+  ComponentContext,
   ComponentListener,
-  ComponentValueProvider,
+  DefinitionContext,
   DefinitionListener,
-  DefinitionValueProvider,
 } from './component';
 import { ComponentRegistry } from './component/definition/component-registry';
 import { ComponentValueRegistry } from './component/definition/component-value-registry';
@@ -66,12 +66,12 @@ function initBootstrap(valueRegistry: BootstrapValueRegistry) {
       return componentRegistry.whenDefined(componentType);
     }
 
-    forDefinitions<S>(key: ContextValueKey<any, S>, provider: DefinitionValueProvider<S>): void {
-      definitionValueRegistry.provide(key, provider);
+    forDefinitions<S>(spec: ContextValueSpec<DefinitionContext<any>, any, S>): void {
+      definitionValueRegistry.provide(spec);
     }
 
-    forComponents<S>(key: ContextValueKey<any, S>, provider: ComponentValueProvider<S>): void {
-      componentValueRegistry.provide(key, provider);
+    forComponents<S>(spec: ContextValueSpec<ComponentContext<any>, any, S>): void {
+      componentValueRegistry.provide(spec);
     }
 
   }

--- a/src/common/context/context-value-registry.spec.ts
+++ b/src/common/context/context-value-registry.spec.ts
@@ -15,7 +15,7 @@ describe('common/context/context-value-registry', () => {
       registry = new ContextValueRegistry();
       values = registry.newValues();
       providerSpy = jasmine.createSpy('provider');
-      registry.provide(key, providerSpy);
+      registry.provide({ provide: key, provider: providerSpy });
     });
 
     describe('Single value', () => {
@@ -38,7 +38,7 @@ describe('common/context/context-value-registry', () => {
         const defaultValue = 'default';
         const keyWithDefaults = new SingleValueKey(key.name, () => defaultValue);
 
-        registry.provide(keyWithDefaults, () => null);
+        registry.provide({ provide: keyWithDefaults, value: null });
 
         expect(values.get(keyWithDefaults)).toBe(defaultValue);
       });
@@ -114,8 +114,8 @@ describe('common/context/context-value-registry', () => {
         expect(values.get(multiKey)).toEqual([]);
       });
       it('is associated with empty array if providers did not return any values', () => {
-        registry.provide(multiKey, () => null);
-        registry.provide(multiKey, () => undefined);
+        registry.provide({ provide: multiKey, value: null });
+        registry.provide({ provide: multiKey, value: undefined });
 
         expect(values.get(multiKey)).toEqual([]);
       });
@@ -131,20 +131,20 @@ describe('common/context/context-value-registry', () => {
         const defaultValue = ['default'];
         const keyWithDefaults = new MultiValueKey('key', () => defaultValue);
 
-        registry.provide(keyWithDefaults, () => null);
-        registry.provide(keyWithDefaults, () => undefined);
+        registry.provide({ provide: keyWithDefaults, value: null });
+        registry.provide({ provide: keyWithDefaults, value: undefined });
 
         expect(values.get(keyWithDefaults)).toEqual(defaultValue);
       });
       it('is associated with provided values array', () => {
-        registry.provide(multiKey, () => 'a');
-        registry.provide(multiKey, () => undefined);
-        registry.provide(multiKey, () => 'c');
+        registry.provide({ provide: multiKey, value: 'a' });
+        registry.provide({ provide: multiKey, value: undefined });
+        registry.provide({ provide: multiKey, value: 'c' });
 
         expect(values.get(multiKey)).toEqual(['a', 'c']);
       });
       it('is associated with value', () => {
-        registry.provide(multiKey, () => 'value');
+        registry.provide({ provide: multiKey, value: 'value' });
 
         expect(values.get(multiKey)).toEqual(['value']);
       });
@@ -180,7 +180,7 @@ describe('common/context/context-value-registry', () => {
 
       beforeEach(() => {
         provider2Spy = jasmine.createSpy('provider2');
-        registry.provide(key, provider2Spy);
+        registry.provide({ provide: key, provider: provider2Spy });
       });
 
       it('provides the last constructed value', () => {
@@ -223,7 +223,7 @@ describe('common/context/context-value-registry', () => {
 
         providerSpy.and.returnValue(value1);
 
-        chained.provide(key, provider2Spy);
+        chained.provide({ provide: key, provider: provider2Spy });
         provider2Spy.and.returnValue(value2);
 
         expect(chainedValues.get(key)).toBe(value2);
@@ -234,7 +234,7 @@ describe('common/context/context-value-registry', () => {
 
         providerSpy.and.returnValue(value1);
 
-        chained.provide(key, provider2Spy);
+        chained.provide({ provide: key, provider: provider2Spy });
         provider2Spy.and.returnValue(null);
 
         expect(chainedValues.get(key)).toBe(value1);
@@ -255,14 +255,14 @@ describe('common/context/context-value-registry', () => {
 
       it('contains all sources', () => {
         providerSpy.and.returnValue('1');
-        registry2.provide(key, () => '2');
-        registry2.provide(key, () => '3');
+        registry2.provide({ provide: key, value: '2' });
+        registry2.provide({ provide: key, value: '3' });
         expect([...combined.sources(context, key)]).toEqual(['1', '2', '3']);
       });
       it('contains reverted sources', () => {
         providerSpy.and.returnValue('1');
-        registry2.provide(key, () => '2');
-        registry2.provide(key, () => '3');
+        registry2.provide({ provide: key, value: '2' });
+        registry2.provide({ provide: key, value: '3' });
         expect([...combined.sources(context, key).reverse()]).toEqual(['3', '2', '1']);
       });
     });

--- a/src/common/context/context-value-registry.ts
+++ b/src/common/context/context-value-registry.ts
@@ -2,7 +2,7 @@ import { RevertibleIterable } from '../iteration';
 import {
   ContextValueDefaultHandler,
   ContextValueKey,
-  ContextValueProvider,
+  ContextValueProvider, ContextValueRequest,
   ContextValueSource,
   ContextValueSourcesKey,
 } from './context-value';
@@ -106,7 +106,10 @@ export class ContextValueRegistry<C extends ContextValues> {
 
     class Values implements ContextValues {
 
-      get<V, S>(this: C, key: ContextValueKey<V, S>, defaultValue?: V | null | undefined): V | null | undefined {
+      get<V, S>(
+          this: C,
+          { key }: { key: ContextValueKey<V, S> },
+          defaultValue?: V | null | undefined): V | null | undefined {
 
         const context = this;
         const cached: V | undefined = values.get(key);

--- a/src/common/context/context-value-registry.ts
+++ b/src/common/context/context-value-registry.ts
@@ -45,9 +45,7 @@ export class ContextValueRegistry<C extends ContextValues> {
    */
   provide<S>(spec: ContextValueSpec<C, any, S>): void {
 
-    const { provide, provider } = ContextValueDef.of(spec);
-    const key = provide.key;
-    const sourcesKey = key.sourcesKey;
+    const { provide: { key: { sourcesKey } }, provider } = ContextValueDef.of(spec);
     let providers: ContextValueProvider<C, S>[] | undefined = this._providers.get(sourcesKey);
 
     if (providers == null) {

--- a/src/common/context/context-value.spec.ts
+++ b/src/common/context/context-value.spec.ts
@@ -14,7 +14,7 @@ describe('common/context/context-value', () => {
       it('uses context value definition as is', () => {
 
         const spec: ContextValueDef<ContextValues, string> = {
-          key: new SingleValueKey<string>('value'),
+          provide: new SingleValueKey<string>('value'),
           provider: () => 'foo',
         };
 
@@ -23,12 +23,12 @@ describe('common/context/context-value', () => {
       it('converts context constant to definition', () => {
 
         const spec: ContextConstDef<ContextValues, string> = {
-          key: new SingleValueKey<string>('value'),
+          provide: new SingleValueKey<string>('value'),
           value: 'foo',
         };
         const def = ContextValueDef.of(spec);
 
-        expect(def.key).toBe(spec.key);
+        expect(def.provide).toBe(spec.provide);
         expect(def.provider(context)).toBe(spec.value);
       });
     });

--- a/src/common/context/context-value.ts
+++ b/src/common/context/context-value.ts
@@ -2,6 +2,22 @@ import { RevertibleIterable } from '../iteration';
 import { ContextValues } from './context-values';
 
 /**
+ * A request for context value.
+ *
+ * This is passed to `ContextValues.get()` methods in order to obtain a context value.
+ *
+ * This is typically a context value key. But may also be any object with `key` property containing such key.
+ */
+export interface ContextValueRequest<V> {
+
+  /**
+   * A key of context value to request.
+   */
+  readonly key: ContextValueKey<V, any>;
+
+}
+
+/**
  * Context value key.
  *
  * Every key should be an unique instance of this class.
@@ -12,7 +28,7 @@ import { ContextValues } from './context-values';
  * @param <V> A type of associated value.
  * @param <S> A type of source values.
  */
-export abstract class ContextValueKey<V, S = V> {
+export abstract class ContextValueKey<V, S = V> implements ContextValueRequest<V> {
 
   /**
    * Human-readable key name.
@@ -36,6 +52,13 @@ export abstract class ContextValueKey<V, S = V> {
    */
   protected constructor(name: string) {
     this.name = name;
+  }
+
+  /**
+   * Always self. This is to use context value keys as context value requests.
+   */
+  get key(): this {
+    return this;
   }
 
   /**

--- a/src/common/context/context-values.ts
+++ b/src/common/context/context-values.ts
@@ -1,4 +1,4 @@
-import { ContextValueKey } from './context-value';
+import { ContextValueRequest } from './context-value';
 
 /**
  * The values available from context.
@@ -7,18 +7,17 @@ import { ContextValueKey } from './context-value';
  */
 export interface ContextValues {
 
-  get<V, S>(key: ContextValueKey<V, S>, defaultValue?: V): V;
+  get<V>(request: ContextValueRequest<V>, defaultValue?: V): V;
 
-  get<V, S>(key: ContextValueKey<V, S>, defaultValue: V | null): V | null;
+  get<V>(request: ContextValueRequest<V>, defaultValue: V | null): V | null;
 
-  get<V, S>(key: ContextValueKey<V, S>, defaultValue: V | undefined): V | undefined;
+  get<V>(request: ContextValueRequest<V>, defaultValue: V | undefined): V | undefined;
 
   /**
    * Returns a value associated with the given key.
    *
    * @param <V> A type of associated value.
-   * @param <S> A type of source values.
-   * @param key Target key.
+   * @param request Context value request with target key.
    * @param defaultValue Default value to return if there is no value associated with the given key. Can be `null`
    * or `undefined` too.
    *
@@ -27,6 +26,6 @@ export interface ContextValues {
    * @throws Error If there is no value associated with the given key and the default key is not provided neither
    * as function argument, nor as `ContextValueKey.defaultValue` property.
    */
-  get<V, S>(key: ContextValueKey<V, S>, defaultValue: V | null | undefined): V | null | undefined;
+  get<V>(request: ContextValueRequest<V>, defaultValue: V | null | undefined): V | null | undefined;
 
 }

--- a/src/common/events/state-events.ts
+++ b/src/common/events/state-events.ts
@@ -1,7 +1,9 @@
 import { list2array } from '../../util';
+import { ContextValueKey, SingleValueKey } from '../context';
+import { noop } from '../functions';
 
 /**
- * A consumer of state updates.
+ * A state updates consumer function.
  *
  * It is called when the value with the given `key` changes.
  *
@@ -10,7 +12,21 @@ import { list2array } from '../../util';
  * @param newValue New value.
  * @param oldValue Previous value.
  */
-export type StateUpdateConsumer = <V>(this: void, key: StateValueKey, newValue: V, oldValue: V) => void;
+export type StateUpdater = <V>(this: void, key: StateValueKey, newValue: V, oldValue: V) => void;
+
+export namespace StateUpdater {
+
+  /**
+   * A key of component context value containing a component state updates consumer function.
+   *
+   * Features are calling this function by default when component state changes, e.g. attribute value or DOM property
+   * modified.
+   *
+   * Note that this value is not provided, unless the `StateSupport` feature is enabled.
+   */
+  export const key: ContextValueKey<StateUpdater> = new SingleValueKey('state-update', () => noop);
+
+}
 
 /**
  * A key of the state value.

--- a/src/component/component-context.ts
+++ b/src/component/component-context.ts
@@ -9,6 +9,11 @@ import {
 } from '../common';
 import { ComponentClass } from './component';
 
+const componentContextKey: ContextValueKey<ComponentContext<any>> = new SingleValueKey('component-context');
+const contentRootKey: ContextValueKey<ContentRoot> = new SingleValueKey(
+    'content-root',
+    ctx => ctx.get(componentContextKey).element);
+
 /**
  * Component context.
  *
@@ -31,15 +36,7 @@ export abstract class ComponentContext<T extends object = object> implements Con
    *
    * It is useful e.g. when constructing default context values relying on context instance.
    */
-  static readonly key: ContextValueKey<ComponentContext<any>> = new SingleValueKey('component-context');
-
-  /**
-   * A key of component context value containing a component root element.
-   *
-   * This is an element itself by default. But can be overridden e.g. by `@AttachShadow` decorator.
-   */
-  static readonly contentRootKey: ContextValueKey<ParentNode> =
-      new SingleValueKey('content-root', ctx => ctx.get(ComponentContext).element);
+  static readonly key = componentContextKey;
 
   /**
    * Component class constructor.
@@ -131,10 +128,10 @@ export abstract class ComponentContext<T extends object = object> implements Con
   /**
    * Component content root.
    *
-   * This is a shorthand for requesting c ontent root instance available under `[ComponentContext.contentRootKey]` key.
+   * This is a shorthand for requesting content root instance available under `[ContentRoot.key]` key.
    */
   get contentRoot(): ParentNode {
-    return this.get(ComponentContext.contentRootKey);
+    return this.get(contentRootKey);
   }
 
   /**
@@ -177,6 +174,22 @@ export abstract class ComponentContext<T extends object = object> implements Con
    * as function argument, nor as `ContextValueKey.defaultValue` property.
    */
   abstract get<V>(request: ContextValueRequest<V>, defaultValue: V | null | undefined): V | null | undefined;
+
+}
+
+/**
+ * Component content root node.
+ */
+export type ContentRoot = ParentNode;
+
+export namespace ContentRoot {
+
+  /**
+   * A key of component context value containing a component root element.
+   *
+   * This is an element itself by default. But can be overridden e.g. by `@AttachShadow` decorator.
+   */
+  export const key = contentRootKey;
 
 }
 

--- a/src/component/component-context.ts
+++ b/src/component/component-context.ts
@@ -181,21 +181,6 @@ export abstract class ComponentContext<T extends object = object> implements Con
 }
 
 /**
- * Component context value provider.
- *
- * It is responsible for constructing the values associated with particular key for each component.
- *
- * This function is called at most once per component.
- *
- * @param <S> The type of source value.
- * @param context Target component context.
- *
- * @return Either constructed value, or `null`/`undefined` if the value can not be constructed.
- */
-export type ComponentValueProvider<S> =
-    <T extends object>(this: void, context: ComponentContext<T>) => S | null | undefined;
-
-/**
  * Component construction listener.
  *
  * It is notified on new component instance construction when registered with `BootstrapContext.onComponent()`

--- a/src/component/component-context.ts
+++ b/src/component/component-context.ts
@@ -1,10 +1,10 @@
 import {
-  ContextValueKey, ContextValueRequest,
+  ContextValueKey,
+  ContextValueRequest,
   ContextValues,
   EventProducer,
-  noop,
   SingleValueKey,
-  StateUpdateConsumer,
+  StateUpdater,
   StateValueKey,
 } from '../common';
 import { ComponentClass } from './component';
@@ -40,17 +40,6 @@ export abstract class ComponentContext<T extends object = object> implements Con
    */
   static readonly contentRootKey: ContextValueKey<ParentNode> =
       new SingleValueKey('content-root', ctx => ctx.get(ComponentContext).element);
-
-  /**
-   * A key of component context value containing a component state update function.
-   *
-   * Features are calling this function by default when component state changes, e.g. attribute value or DOM property
-   * modified.
-   *
-   * Note that this value is not provided, unless the `StateSupport` feature is enabled.
-   */
-  static readonly stateUpdateKey: ContextValueKey<StateUpdateConsumer> =
-      new SingleValueKey('state-update', () => noop);
 
   /**
    * Component class constructor.
@@ -105,19 +94,18 @@ export abstract class ComponentContext<T extends object = object> implements Con
   /**
    * Updates component's state.
    *
-   * This is a shorthand for invoking a component state update function available under
-   * `[ComponentContext.stateUpdateKey]` key.
+   * This is a shorthand for invoking a component state update function available under `[StateUpdater.key]` key.
    *
-   * Note that state update has no effect unless `StateSupport` feature is enabled or
-   * `[ComponentContext.stateUpdateKey]` context value is provided by other means.
+   * Note that state update has no effect unless `StateSupport` feature is enabled or `[StateUpdater.key]` context value
+   * is provided by other means.
    *
    * @param <V> A type of changed value.
    * @param key Changed value key.
    * @param newValue New value.
    * @param oldValue Previous value.
    */
-  readonly updateState: StateUpdateConsumer = (<V>(key: StateValueKey, newValue: V, oldValue: V) => {
-    this.get(ComponentContext.stateUpdateKey)(key, newValue, oldValue);
+  readonly updateState: StateUpdater = (<V>(key: StateValueKey, newValue: V, oldValue: V) => {
+    this.get(StateUpdater)(key, newValue, oldValue);
   });
 
   /**

--- a/src/component/component-context.ts
+++ b/src/component/component-context.ts
@@ -1,5 +1,5 @@
 import {
-  ContextValueKey,
+  ContextValueKey, ContextValueRequest,
   ContextValues,
   EventProducer,
   noop,
@@ -39,7 +39,7 @@ export abstract class ComponentContext<T extends object = object> implements Con
    * This is an element itself by default. But can be overridden e.g. by `@AttachShadow` decorator.
    */
   static readonly contentRootKey: ContextValueKey<ParentNode> =
-      new SingleValueKey('content-root', ctx => ctx.get(ComponentContext.key).element);
+      new SingleValueKey('content-root', ctx => ctx.get(ComponentContext).element);
 
   /**
    * A key of component context value containing a component state update function.
@@ -169,18 +169,17 @@ export abstract class ComponentContext<T extends object = object> implements Con
    */
   abstract elementSuper(name: string): any;
 
-  abstract get<V, S>(key: ContextValueKey<V, S>, defaultValue?: V): V;
+  abstract get<V>(request: ContextValueRequest<V>, defaultValue?: V): V;
 
-  abstract get<V, S>(key: ContextValueKey<V, S>, defaultValue: V | null): V | null;
+  abstract get<V>(request: ContextValueRequest<V>, defaultValue: V | null): V | null;
 
-  abstract get<V, S>(key: ContextValueKey<V, S>, defaultValue: V | undefined): V | undefined;
+  abstract get<V>(request: ContextValueRequest<V>, defaultValue: V | undefined): V | undefined;
 
   /**
    * Returns a value associated with the given key.
    *
    * @param <V> A type of associated value.
-   * @param <S> A type of source values.
-   * @param key Target key.
+   * @param request Context value request with target key.
    * @param defaultValue Default value to return if there is no value associated with the given key. Can be `null`
    * or `undefined` too.
    *
@@ -189,7 +188,7 @@ export abstract class ComponentContext<T extends object = object> implements Con
    * @throws Error If there is no value associated with the given key and the default key is not provided neither
    * as function argument, nor as `ContextValueKey.defaultValue` property.
    */
-  abstract get<V, S>(key: ContextValueKey<V, S>, defaultValue: V | null | undefined): V | null | undefined;
+  abstract get<V>(request: ContextValueRequest<V>, defaultValue: V | null | undefined): V | null | undefined;
 
 }
 

--- a/src/component/definition/component-registry.spec.ts
+++ b/src/component/definition/component-registry.spec.ts
@@ -1,4 +1,4 @@
-import { ContextValueKey } from '../../common';
+import { ContextValueKey, ContextValueRequest } from '../../common';
 import { BootstrapContext } from '../../feature';
 import { ComponentClass } from '../component';
 import { ComponentDef } from '../component-def';
@@ -19,8 +19,8 @@ describe('component/definition/component-registry', () => {
 
     beforeEach(() => {
       bootstrapContextSpy = jasmine.createSpyObj('bootstrapContext', ['get']);
-      bootstrapContextSpy.get.and.callFake((key: ContextValueKey<any>) => {
-        if (key === CustomElements.key) {
+      bootstrapContextSpy.get.and.callFake((request: ContextValueRequest<any>) => {
+        if (request.key === CustomElements.key) {
           return customElementsSpy;
         }
         return;

--- a/src/component/definition/component-registry.ts
+++ b/src/component/definition/component-registry.ts
@@ -32,7 +32,7 @@ export class ComponentRegistry {
   }
 
   get customElements(): CustomElements {
-    return this.bootstrapContext.get(CustomElements.key);
+    return this.bootstrapContext.get(CustomElements);
   }
 
   define<T extends object>(componentType: ComponentClass<T>) {

--- a/src/component/definition/custom-elements.spec.ts
+++ b/src/component/definition/custom-elements.spec.ts
@@ -32,7 +32,7 @@ describe('component/definition/custom-elements', () => {
     });
 
     beforeEach(() => {
-      customElements = context.get(CustomElements.key);
+      customElements = context.get(CustomElements);
     });
 
     beforeEach(() => {

--- a/src/component/definition/custom-elements.spec.ts
+++ b/src/component/definition/custom-elements.spec.ts
@@ -28,7 +28,7 @@ describe('component/definition/custom-elements', () => {
         get: valueRegistry.newValues().get,
       } as any;
 
-      valueRegistry.provide(BootstrapContext.windowKey, () => windowSpy);
+      valueRegistry.provide({ provide: BootstrapContext.windowKey, value: windowSpy });
     });
 
     beforeEach(() => {

--- a/src/component/definition/custom-elements.spec.ts
+++ b/src/component/definition/custom-elements.spec.ts
@@ -1,7 +1,7 @@
 import SpyObj = jasmine.SpyObj;
 import { Class } from '../../common';
 import { ContextValueRegistry } from '../../common/context';
-import { BootstrapContext } from '../../feature';
+import { BootstrapContext, BootstrapWindow } from '../../feature';
 import { ComponentClass } from '../component';
 import { ComponentDef } from '../component-def';
 import { CustomElements } from './custom-elements';
@@ -28,7 +28,7 @@ describe('component/definition/custom-elements', () => {
         get: valueRegistry.newValues().get,
       } as any;
 
-      valueRegistry.provide({ provide: BootstrapContext.windowKey, value: windowSpy });
+      valueRegistry.provide({ provide: BootstrapWindow, value: windowSpy });
     });
 
     beforeEach(() => {

--- a/src/component/definition/custom-elements.ts
+++ b/src/component/definition/custom-elements.ts
@@ -1,5 +1,5 @@
 import { Class, ContextValueKey, SingleValueKey } from '../../common';
-import { BootstrapContext } from '../../feature';
+import { BootstrapWindow } from '../../feature';
 import { ComponentClass } from '../component';
 import { ComponentDef } from '../component-def';
 
@@ -8,7 +8,7 @@ import { ComponentDef } from '../component-def';
  *
  * This is used to register custom elements.
  *
- * Typically implemented by to `window.customElements`.
+ * Typically implemented by `window.customElements`.
  */
 export abstract class CustomElements {
 
@@ -16,13 +16,13 @@ export abstract class CustomElements {
    * A key of bootstrap context value containing a `CustomElements` instance used to register custom
    * elements.
    *
-   * Target value defaults to `window.customElements` from the window provided under `windowKey`.
+   * Target value defaults to `window.customElements` from the window provided under `[BootstrapWindow.key]`.
    */
   static readonly key: ContextValueKey<CustomElements> = new SingleValueKey<CustomElements>(
       'custom-elements',
       values => {
 
-        const customElements = values.get(BootstrapContext.windowKey).customElements;
+        const customElements = values.get(BootstrapWindow).customElements;
 
         class WindowCustomElements extends CustomElements {
 

--- a/src/component/definition/definition-context.ts
+++ b/src/component/definition/definition-context.ts
@@ -21,17 +21,6 @@ import { ComponentContext, ComponentListener } from '../component-context';
 export abstract class DefinitionContext<T extends object> implements ContextValues {
 
   /**
-   * A key of definition context value containing a base element class constructor.
-   *
-   * This value is the class the custom elements are inherited from unless `ComponentDef.extend.type` is specified.
-   *
-   * Target value defaults to `HTMLElement` from the window provided under `[BootstrapWindow.key]`.
-   */
-  static readonly baseElementKey = new SingleValueKey<Class>(
-      'base-element',
-      values => (values.get(BootstrapWindow) as any).HTMLElement);
-
-  /**
    * Component class constructor.
    */
   abstract readonly componentType: ComponentClass<T>;
@@ -98,6 +87,26 @@ export abstract class DefinitionContext<T extends object> implements ContextValu
    * as function argument, nor as `ContextValueKey.defaultValue` property.
    */
   abstract get<V>(request: ContextValueRequest<V>, defaultValue: V | null | undefined): V | null | undefined;
+
+}
+
+/**
+ * Base element class constructor.
+ */
+export type ElementBaseClass<T extends object = object> = Class<T>;
+
+export namespace ElementBaseClass {
+
+  /**
+   * A key of definition context value containing a base element class constructor.
+   *
+   * This value is the class the custom elements are inherited from unless `ComponentDef.extend.type` is specified.
+   *
+   * Target value defaults to `HTMLElement` from the window provided under `[BootstrapWindow.key]`.
+   */
+  export const key = new SingleValueKey<ElementBaseClass>(
+      'element-base-class',
+      values => (values.get(BootstrapWindow) as any).HTMLElement);
 
 }
 

--- a/src/component/definition/definition-context.ts
+++ b/src/component/definition/definition-context.ts
@@ -1,14 +1,14 @@
 import {
   Class,
-  ContextValueKey,
   ContextValueRequest,
   ContextValues,
+  ContextValueSpec,
   EventProducer,
   SingleValueKey,
 } from '../../common';
 import { BootstrapContext } from '../../feature';
 import { ComponentClass } from '../component';
-import { ComponentListener, ComponentValueProvider } from '../component-context';
+import { ComponentContext, ComponentListener } from '../component-context';
 
 /**
  * Component definition context.
@@ -73,11 +73,10 @@ export abstract class DefinitionContext<T extends object> implements ContextValu
    *
    * The given provider will be requested for the value at most once per component.
    *
-   * @param <S> The type of source value.
-   * @param key Component context value key the provider should associate the value with.
-   * @param provider Component context value provider to register.
+   * @param <S> The type of context value sources.
+   * @param spec Component context value specifier.
    */
-  abstract forComponents<S>(key: ContextValueKey<any, S>, provider: ComponentValueProvider<S>): void;
+  abstract forComponents<S>(spec: ContextValueSpec<ComponentContext<any>, any, S>): void;
 
   abstract get<V>(request: ContextValueRequest<V>, defaultValue?: V): V;
 
@@ -101,21 +100,6 @@ export abstract class DefinitionContext<T extends object> implements ContextValu
   abstract get<V>(request: ContextValueRequest<V>, defaultValue: V | null | undefined): V | null | undefined;
 
 }
-
-/**
- * Component definition context value provider.
- *
- * It is responsible for constructing the values associated with particular key for each component type.
- *
- * This function is called at most once per component type.
- *
- * @param <S> The type of source value.
- * @param context Target component definition context.
- *
- * @return Either constructed value, or `null`/`undefined` if the value can not be constructed.
- */
-export type DefinitionValueProvider<S> =
-    <T extends object>(this: void, context: DefinitionContext<T>) => S | null | undefined;
 
 /**
  * Component definition listener.

--- a/src/component/definition/definition-context.ts
+++ b/src/component/definition/definition-context.ts
@@ -9,6 +9,7 @@ import {
 import { BootstrapWindow } from '../../feature';
 import { ComponentClass } from '../component';
 import { ComponentContext, ComponentListener } from '../component-context';
+import { ComponentDef } from '../component-def';
 
 /**
  * Component definition context.
@@ -105,13 +106,20 @@ export namespace ElementBaseClass {
   /**
    * A key of definition context value containing a base element class constructor.
    *
-   * This value is the class the custom elements are inherited from unless `ComponentDef.extend.type` is specified.
+   * This value is the class the custom elements are inherited from.
    *
-   * Target value defaults to `HTMLElement` from the window provided under `[BootstrapWindow.key]`.
+   * Target value defaults to `HTMLElement` from the window provided under `[BootstrapWindow.key]`,
+   * unless `ComponentDef.extend.type` is specified.
    */
   export const key = new SingleValueKey<ElementBaseClass>(
       'element-base-class',
-      values => (values.get(BootstrapWindow) as any).HTMLElement);
+      values => {
+
+        const componentType = values.get(DefinitionContext).componentType;
+        const extend = ComponentDef.of(componentType).extend;
+
+        return extend && extend.type ||  (values.get(BootstrapWindow) as any).HTMLElement;
+      });
 
 }
 

--- a/src/component/definition/definition-context.ts
+++ b/src/component/definition/definition-context.ts
@@ -1,4 +1,11 @@
-import { Class, ContextValueKey, ContextValues, EventProducer, SingleValueKey } from '../../common';
+import {
+  Class,
+  ContextValueKey,
+  ContextValueRequest,
+  ContextValues,
+  EventProducer,
+  SingleValueKey,
+} from '../../common';
 import { BootstrapContext } from '../../feature';
 import { ComponentClass } from '../component';
 import { ComponentListener, ComponentValueProvider } from '../component-context';
@@ -72,18 +79,17 @@ export abstract class DefinitionContext<T extends object> implements ContextValu
    */
   abstract forComponents<S>(key: ContextValueKey<any, S>, provider: ComponentValueProvider<S>): void;
 
-  abstract get<V, S>(key: ContextValueKey<V, S>, defaultValue?: V): V;
+  abstract get<V>(request: ContextValueRequest<V>, defaultValue?: V): V;
 
-  abstract get<V, S>(key: ContextValueKey<V, S>, defaultValue: V | null): V | null;
+  abstract get<V>(request: ContextValueRequest<V>, defaultValue: V | null): V | null;
 
-  abstract get<V, S>(key: ContextValueKey<V, S>, defaultValue: V | undefined): V | undefined;
+  abstract get<V>(request: ContextValueRequest<V>, defaultValue: V | undefined): V | undefined;
 
   /**
    * Returns a value associated with the given key.
    *
    * @param <V> A type of associated value.
-   * @param <S> A type of source values.
-   * @param key Target key.
+   * @param request Context value request with target key.
    * @param defaultValue Default value to return if there is no value associated with the given key. Can be `null`
    * or `undefined` too.
    *
@@ -92,7 +98,7 @@ export abstract class DefinitionContext<T extends object> implements ContextValu
    * @throws Error If there is no value associated with the given key and the default key is not provided neither
    * as function argument, nor as `ContextValueKey.defaultValue` property.
    */
-  abstract get<V, S>(key: ContextValueKey<V, S>, defaultValue: V | null | undefined): V | null | undefined;
+  abstract get<V>(request: ContextValueRequest<V>, defaultValue: V | null | undefined): V | null | undefined;
 
 }
 

--- a/src/component/definition/definition-context.ts
+++ b/src/component/definition/definition-context.ts
@@ -6,7 +6,7 @@ import {
   EventProducer,
   SingleValueKey,
 } from '../../common';
-import { BootstrapContext } from '../../feature';
+import { BootstrapWindow } from '../../feature';
 import { ComponentClass } from '../component';
 import { ComponentContext, ComponentListener } from '../component-context';
 
@@ -23,13 +23,13 @@ export abstract class DefinitionContext<T extends object> implements ContextValu
   /**
    * A key of definition context value containing a base element class constructor.
    *
-   * This value is the class the custom elements are inherited from unless `ComponentDef.extends.type` is specified.
+   * This value is the class the custom elements are inherited from unless `ComponentDef.extend.type` is specified.
    *
-   * Target value defaults to `HTMLElement` from the window provided under `windowKey`.
+   * Target value defaults to `HTMLElement` from the window provided under `[BootstrapWindow.key]`.
    */
   static readonly baseElementKey = new SingleValueKey<Class>(
       'base-element',
-      values => (values.get(BootstrapContext.windowKey) as any).HTMLElement);
+      values => (values.get(BootstrapWindow) as any).HTMLElement);
 
   /**
    * Component class constructor.

--- a/src/component/definition/definition-context.ts
+++ b/src/component/definition/definition-context.ts
@@ -1,5 +1,5 @@
 import {
-  Class,
+  Class, ContextValueKey,
   ContextValueRequest,
   ContextValues,
   ContextValueSpec,
@@ -19,6 +19,11 @@ import { ComponentContext, ComponentListener } from '../component-context';
  * @param <T> A type of component.
  */
 export abstract class DefinitionContext<T extends object> implements ContextValues {
+
+  /**
+   * A key of definition context value containing a definition context itself.
+   */
+  static readonly key: ContextValueKey<DefinitionContext<any>> = new SingleValueKey('definition-context');
 
   /**
    * Component class constructor.

--- a/src/component/definition/element-builder.spec.ts
+++ b/src/component/definition/element-builder.spec.ts
@@ -2,9 +2,8 @@ import { Class, EventInterest, SingleValueKey } from '../../common';
 import { ComponentClass } from '../component';
 import { ComponentContext } from '../component-context';
 import { ComponentDef } from '../component-def';
-import { WesComponent } from '../wes-component.decorator';
 import { ComponentValueRegistry } from './component-value-registry';
-import { DefinitionContext } from './definition-context';
+import { DefinitionContext, ElementBaseClass } from './definition-context';
 import { DefinitionValueRegistry } from './definition-value-registry';
 import { ElementBuilder } from './element-builder';
 import Spy = jasmine.Spy;
@@ -125,7 +124,7 @@ describe('component/definition/element-builder', () => {
         });
       });
       beforeEach(() => {
-        definitionValueRegistry.provide({ provide: DefinitionContext.baseElementKey, value: Object });
+        definitionValueRegistry.provide({ provide: ElementBaseClass, value: Object });
       });
       beforeEach(() => {
 
@@ -167,7 +166,7 @@ describe('component/definition/element-builder', () => {
         });
       });
       beforeEach(() => {
-        definitionValueRegistry.provide({ provide: DefinitionContext.baseElementKey, value: Object });
+        definitionValueRegistry.provide({ provide: ElementBaseClass, value: Object });
       });
       beforeEach(() => {
 

--- a/src/component/definition/element-builder.spec.ts
+++ b/src/component/definition/element-builder.spec.ts
@@ -112,7 +112,7 @@ describe('component/definition/element-builder', () => {
         value = 'some value';
         builder.definitions.on((ctx: DefinitionContext<any>) => {
           if (ctx.componentType === TestComponent) {
-            ctx.forComponents(key, () => value);
+            ctx.forComponents({ provide: key, value });
           }
         });
       });
@@ -120,12 +120,12 @@ describe('component/definition/element-builder', () => {
         value2 = 'other value';
         ComponentDef.define(TestComponent, {
           define(context: DefinitionContext<any>) {
-            context.forComponents(key2, () => value2);
+            context.forComponents({ provide: key2, value: value2 });
           }
         });
       });
       beforeEach(() => {
-        definitionValueRegistry.provide(DefinitionContext.baseElementKey, () => Object);
+        definitionValueRegistry.provide({ provide: DefinitionContext.baseElementKey, value: Object });
       });
       beforeEach(() => {
 
@@ -167,7 +167,7 @@ describe('component/definition/element-builder', () => {
         });
       });
       beforeEach(() => {
-        definitionValueRegistry.provide(DefinitionContext.baseElementKey, () => Object);
+        definitionValueRegistry.provide({ provide: DefinitionContext.baseElementKey, value: Object });
       });
       beforeEach(() => {
 

--- a/src/component/definition/element-builder.spec.ts
+++ b/src/component/definition/element-builder.spec.ts
@@ -105,11 +105,13 @@ describe('component/definition/element-builder', () => {
       let value: string;
       const key2 = new SingleValueKey<string>('another-key');
       let value2: string;
+      let definitionContext: DefinitionContext<any>;
       let componentContext: ComponentContext;
 
       beforeEach(() => {
         value = 'some value';
         builder.definitions.on((ctx: DefinitionContext<any>) => {
+          definitionContext = ctx;
           if (ctx.componentType === TestComponent) {
             ctx.forComponents({ provide: key, value });
           }
@@ -133,6 +135,11 @@ describe('component/definition/element-builder', () => {
         componentContext = ComponentContext.of(element);
       });
 
+      describe('DefinitionContext', () => {
+        it('is available as context value', () => {
+          expect(definitionContext.get(DefinitionContext)).toBe(definitionContext);
+        });
+      });
       it('is available to component', () => {
         expect(componentContext.get(key)).toBe(value);
         expect(componentContext.get(key2)).toBe(value2);

--- a/src/component/definition/element-builder.ts
+++ b/src/component/definition/element-builder.ts
@@ -3,7 +3,7 @@ import { Component, ComponentClass } from '../component';
 import { ComponentContext as ComponentContext_, ComponentListener } from '../component-context';
 import { ComponentDef } from '../component-def';
 import { ComponentValueRegistry } from './component-value-registry';
-import { DefinitionContext as DefinitionContext_, DefinitionListener } from './definition-context';
+import { DefinitionContext as DefinitionContext_, DefinitionListener, ElementBaseClass } from './definition-context';
 import { DefinitionValueRegistry } from './definition-value-registry';
 
 /**
@@ -102,8 +102,10 @@ export class ElementBuilder {
     return elementType;
   }
 
-  private _baseElementType<T extends object>(definitionContext: DefinitionContext_<T>, def: ComponentDef<T>): Class {
-    return def.extend && def.extend.type || definitionContext.get(DefinitionContext_.baseElementKey);
+  private _elementBaseClass<T extends object>(
+      definitionContext: DefinitionContext_<T>,
+      def: ComponentDef<T>): ElementBaseClass {
+    return def.extend && def.extend.type || definitionContext.get(ElementBaseClass);
   }
 
   private _elementType<T extends object>(
@@ -114,7 +116,7 @@ export class ElementBuilder {
 
     const { componentType } = definitionContext;
     const builder = this;
-    const baseElementType = this._baseElementType(definitionContext, def);
+    const baseElementType = this._elementBaseClass(definitionContext, def);
 
     const connected = Symbol('connected');
     const connectedCallback = Symbol('connectedCallback');

--- a/src/component/definition/element-builder.ts
+++ b/src/component/definition/element-builder.ts
@@ -52,6 +52,7 @@ export class ElementBuilder {
       constructor() {
         super();
         typeValueRegistry = ComponentValueRegistry.create(builder._definitionValueRegistry.bindSources(this));
+        typeValueRegistry.provide({ provide: DefinitionContext_, value: this });
 
         const values = typeValueRegistry.newValues();
 
@@ -116,13 +117,13 @@ export class ElementBuilder {
 
     const { componentType } = definitionContext;
     const builder = this;
-    const baseElementType = this._elementBaseClass(definitionContext, def);
+    const elementBaseClass = this._elementBaseClass(definitionContext, def);
 
     const connected = Symbol('connected');
     const connectedCallback = Symbol('connectedCallback');
     const disconnectedCallback = Symbol('disconnectedCallback');
 
-    class Element extends baseElementType {
+    class Element extends elementBaseClass {
 
       // Component reference
       [Component.symbol]: T;

--- a/src/component/definition/element-builder.ts
+++ b/src/component/definition/element-builder.ts
@@ -103,12 +103,6 @@ export class ElementBuilder {
     return elementType;
   }
 
-  private _elementBaseClass<T extends object>(
-      definitionContext: DefinitionContext_<T>,
-      def: ComponentDef<T>): ElementBaseClass {
-    return def.extend && def.extend.type || definitionContext.get(ElementBaseClass);
-  }
-
   private _elementType<T extends object>(
       def: ComponentDef<T>,
       definitionContext: DefinitionContext_<T>,
@@ -117,7 +111,7 @@ export class ElementBuilder {
 
     const { componentType } = definitionContext;
     const builder = this;
-    const elementBaseClass = this._elementBaseClass(definitionContext, def);
+    const elementBaseClass = definitionContext.get(ElementBaseClass);
 
     const connected = Symbol('connected');
     const connectedCallback = Symbol('connectedCallback');

--- a/src/component/definition/element-builder.ts
+++ b/src/component/definition/element-builder.ts
@@ -1,6 +1,6 @@
-import { Class, ContextValueKey, EventEmitter, mergeFunctions, noop } from '../../common';
+import { Class, ContextValueKey, ContextValueSpec, EventEmitter, mergeFunctions, noop } from '../../common';
 import { Component, ComponentClass } from '../component';
-import { ComponentContext as ComponentContext_, ComponentListener, ComponentValueProvider } from '../component-context';
+import { ComponentContext as ComponentContext_, ComponentListener } from '../component-context';
 import { ComponentDef } from '../component-def';
 import { ComponentValueRegistry } from './component-value-registry';
 import { DefinitionContext as DefinitionContext_, DefinitionListener } from './definition-context';
@@ -66,8 +66,8 @@ export class ElementBuilder {
         whenReady = mergeFunctions<[Class], void, DefinitionContext>(whenReady, callback);
       }
 
-      forComponents<S>(key: ContextValueKey<any, S>, provider: ComponentValueProvider<S>): void {
-        typeValueRegistry.provide(key, provider);
+      forComponents<S>(spec: ContextValueSpec<ComponentContext_<any>, any, S>): void {
+        typeValueRegistry.provide(spec);
       }
 
     }
@@ -167,7 +167,7 @@ export class ElementBuilder {
 
         const context = new ComponentContext();
 
-        valueRegistry.provide(ComponentContext_.key, () => context);
+        valueRegistry.provide({ provide: ComponentContext_, value: context });
 
         Object.defineProperty(this, ComponentContext_.symbol, { value: context });
         Object.defineProperty(this, connectedCallback, {

--- a/src/feature/bootstrap-context.ts
+++ b/src/feature/bootstrap-context.ts
@@ -1,4 +1,4 @@
-import { ContextValueKey, ContextValues, EventProducer, SingleValueKey } from '../common';
+import { ContextValueKey, ContextValueRequest, ContextValues, EventProducer, SingleValueKey } from '../common';
 import {
   ComponentClass,
   ComponentListener,
@@ -97,18 +97,17 @@ export abstract class BootstrapContext implements ContextValues {
    */
   abstract forComponents<S>(key: ContextValueKey<any, S>, provider: ComponentValueProvider<S>): void;
 
-  abstract get<V, S>(key: ContextValueKey<V, S>, defaultValue?: V): V;
+  abstract get<V>(request: ContextValueRequest<V>, defaultValue?: V): V;
 
-  abstract get<V, S>(key: ContextValueKey<V, S>, defaultValue: V | null): V | null;
+  abstract get<V>(request: ContextValueRequest<V>, defaultValue: V | null): V | null;
 
-  abstract get<V, S>(key: ContextValueKey<V, S>, defaultValue: V | undefined): V | undefined;
+  abstract get<V>(request: ContextValueRequest<V>, defaultValue: V | undefined): V | undefined;
 
   /**
    * Returns a value associated with the given key.
    *
    * @param <V> A type of associated value.
-   * @param <S> A type of source values.
-   * @param key Target key.
+   * @param request Context value request with target key.
    * @param defaultValue Default value to return if there is no value associated with the given key. Can be `null`
    * or `undefined` too.
    *
@@ -117,6 +116,6 @@ export abstract class BootstrapContext implements ContextValues {
    * @throws Error If there is no value associated with the given key and the default key is not provided neither
    * as function argument, nor as `ContextValueKey.defaultValue` property.
    */
-  abstract get<V, S>(key: ContextValueKey<V, S>, defaultValue: V | null | undefined): V | null | undefined;
+  abstract get<V>(request: ContextValueRequest<V>, defaultValue: V | null | undefined): V | null | undefined;
 
 }

--- a/src/feature/bootstrap-context.ts
+++ b/src/feature/bootstrap-context.ts
@@ -1,10 +1,17 @@
-import { ContextValueKey, ContextValueRequest, ContextValues, EventProducer, SingleValueKey } from '../common';
+import {
+  ContextValueKey,
+  ContextValueRequest,
+  ContextValues,
+  ContextValueSpec,
+  EventProducer,
+  SingleValueKey,
+} from '../common';
 import {
   ComponentClass,
+  ComponentContext,
   ComponentListener,
-  ComponentValueProvider,
+  DefinitionContext,
   DefinitionListener,
-  DefinitionValueProvider,
 } from '../component';
 
 /**
@@ -80,22 +87,20 @@ export abstract class BootstrapContext implements ContextValues {
    *
    * The given provider will be requested for the value at most once per component.
    *
-   * @param <S> The type of source value.
-   * @param key Component definition context value key the provider should associate the value with.
-   * @param provider Component definition context value provider to register.
+   * @param <S> The type of context value sources.
+   * @param spec Component definition context value specifier.
    */
-  abstract forDefinitions<S>(key: ContextValueKey<any, S>, provider: DefinitionValueProvider<S>): void;
+  abstract forDefinitions<S>(spec: ContextValueSpec<DefinitionContext<any>, any, S>): void;
 
   /**
    * Registers provider that associates a value with the given key with components.
    *
    * The given provider will be requested for the value at most once per component.
    *
-   * @param <S> The type of source value.
-   * @param key Component context value key the provider should associate the value with.
-   * @param provider Component context value provider to register.
+   * @param <S> The type of context value sources.
+   * @param spec Component context value specifier.
    */
-  abstract forComponents<S>(key: ContextValueKey<any, S>, provider: ComponentValueProvider<S>): void;
+  abstract forComponents<S>(spec: ContextValueSpec<ComponentContext<any>, any, S>): void;
 
   abstract get<V>(request: ContextValueRequest<V>, defaultValue?: V): V;
 

--- a/src/feature/bootstrap-context.ts
+++ b/src/feature/bootstrap-context.ts
@@ -25,13 +25,6 @@ import {
 export abstract class BootstrapContext implements ContextValues {
 
   /**
-   * A key of bootstrap context value containing a window instance the bootstrap is performed against.
-   *
-   * Target value defaults to current window.
-   */
-  static readonly windowKey: ContextValueKey<Window> = new SingleValueKey<Window>('window', () => window);
-
-  /**
    * Registers component definition listener.
    *
    * This listener will be called when new component class is defined, but before its custom element class constructed.

--- a/src/feature/bootstrap-value-registry.ts
+++ b/src/feature/bootstrap-value-registry.ts
@@ -1,4 +1,4 @@
-import { ContextValueKey, ContextValueRegistry, ContextValues, RevertibleIterable } from '../common';
+import { ContextValueRegistry, ContextValues, ProvidedContextValue, RevertibleIterable } from '../common';
 import { BootstrapContext } from './bootstrap-context';
 
 /**
@@ -7,7 +7,7 @@ import { BootstrapContext } from './bootstrap-context';
 export class BootstrapValueRegistry extends ContextValueRegistry<BootstrapContext> {
 
   readonly values: ContextValues;
-  readonly valueSources: <V, S>(this: void, key: ContextValueKey<V, S>) => RevertibleIterable<S>;
+  readonly valueSources: <S>(this: void, request: ProvidedContextValue<S>) => RevertibleIterable<S>;
 
   static create(): BootstrapValueRegistry {
     return new BootstrapValueRegistry();
@@ -16,7 +16,7 @@ export class BootstrapValueRegistry extends ContextValueRegistry<BootstrapContex
   private constructor() {
     super();
     this.values = this.newValues();
-    this.valueSources = <V, S>(key: ContextValueKey<V, S>) => this.values.get.call(this.values, key.sourcesKey);
+    this.valueSources = <S>(request: ProvidedContextValue<S>) => this.values.get.call(this.values, request);
   }
 
 }

--- a/src/feature/bootstrap-window.ts
+++ b/src/feature/bootstrap-window.ts
@@ -1,0 +1,17 @@
+import { ContextValueKey, SingleValueKey } from '../common/context';
+
+/**
+ * A window the components bootstrap is performed against.
+ */
+export type BootstrapWindow = Window;
+
+export namespace BootstrapWindow {
+
+  /**
+   * A key of bootstrap context value containing a window instance the bootstrap is performed against.
+   *
+   * Target value defaults to current window.
+   */
+  export const key: ContextValueKey<BootstrapWindow> = new SingleValueKey('window', () => window);
+
+}

--- a/src/feature/feature-registry.spec.ts
+++ b/src/feature/feature-registry.spec.ts
@@ -143,16 +143,16 @@ describe('feature/feature-registry', () => {
     });
     it('bootstraps value providers', () => {
 
-      const key = new SingleValueKey('test-key');
+      const provide = new SingleValueKey('test-key');
       const provider = jasmine.createSpy('testValueProvider');
       class Feature {}
 
-      FeatureDef.define(Feature, { prebootstrap: { key, provider } });
+      FeatureDef.define(Feature, { prebootstrap: { provide, provider } });
 
       registry.add(Feature);
       registry.bootstrap(contextSpy);
 
-      expect(valueRegistrySpy.provide).toHaveBeenCalledWith(key, provider);
+      expect(valueRegistrySpy.provide).toHaveBeenCalledWith({ provide, provider });
     });
   });
 });

--- a/src/feature/feature-registry.ts
+++ b/src/feature/feature-registry.ts
@@ -118,12 +118,8 @@ export class FeatureRegistry {
   private _provideValues() {
     this._providers.forEach((providers, feature) => {
       if (feature === providers.provider(this._providers)) {
-        list2array(FeatureDef.of(feature).prebootstrap).forEach(spec => {
-
-          const { key, provider } = ContextValueDef.of(spec);
-
-          this._valueRegistry.provide(key, provider);
-        });
+        list2array(FeatureDef.of(feature).prebootstrap)
+            .forEach(spec => this._valueRegistry.provide(spec));
       }
     });
   }

--- a/src/feature/feature.spec.ts
+++ b/src/feature/feature.spec.ts
@@ -70,11 +70,11 @@ describe('feature/feature', () => {
       it('merges `prebootstrap`', () => {
 
         const v1: ContextValueSpec<BootstrapContext, string> = {
-          key: new SingleValueKey<string>('1'),
+          provide: new SingleValueKey<string>('1'),
           value: '1',
         };
         const v2: ContextValueSpec<BootstrapContext, string> = {
-          key: new SingleValueKey<string>('2'),
+          provide: new SingleValueKey<string>('2'),
           value: '2',
         };
 

--- a/src/feature/index.ts
+++ b/src/feature/index.ts
@@ -1,3 +1,4 @@
 export * from './bootstrap-context';
+export * from './bootstrap-window';
 export * from './feature';
 export * from './wes-feature.decorator';

--- a/src/features/attributes/attribute-changed.decorator.ts
+++ b/src/features/attributes/attribute-changed.decorator.ts
@@ -45,7 +45,7 @@ export function AttributeChanged<T extends ComponentClass>(opts?: Attribute.Opts
         {
           define(defContext) {
 
-            const registry = defContext.get(AttributeRegistry.key);
+            const registry = defContext.get(AttributeRegistry);
 
             registry.onAttributeChange(name, function (
                 this: InstanceType<T>,

--- a/src/features/attributes/attribute.decorator.ts
+++ b/src/features/attributes/attribute.decorator.ts
@@ -27,7 +27,7 @@ export function Attribute<T extends ComponentClass>(opts?: Attribute.Opts<T> | s
         componentType,
         {
           define(definitionContext) {
-            definitionContext.get(AttributeRegistry.key).onAttributeChange(name, updateState);
+            definitionContext.get(AttributeRegistry).onAttributeChange(name, updateState);
           }
         });
 

--- a/src/features/attributes/attributes-support.feature.ts
+++ b/src/features/attributes/attributes-support.feature.ts
@@ -5,6 +5,7 @@ import { AttributeChangedCallback, AttributeRegistry as AttributeRegistry_ } fro
 
 class AttributeRegistry<T extends object> implements AttributeRegistry_<T> {
 
+  static readonly key = new SingleValueKey<AttributeRegistry<any>>('attribute-registry:impl');
   private readonly _attrs: { [name: string]: AttributeChangedCallback<T> } = {};
 
   onAttributeChange(name: string, callback: AttributeChangedCallback<T>): void {
@@ -36,8 +37,6 @@ class AttributeRegistry<T extends object> implements AttributeRegistry_<T> {
 
 }
 
-const implKey = new SingleValueKey<AttributeRegistry<any>>('attribute-registry:impl');
-
 /**
  * A feature adding attributes to custom elements.
  *
@@ -46,9 +45,9 @@ const implKey = new SingleValueKey<AttributeRegistry<any>>('attribute-registry:i
  */
 @WesFeature({
   bootstrap(context) {
-    context.forDefinitions(implKey, () => new AttributeRegistry());
-    context.forDefinitions(AttributeRegistry_.key, ctx => ctx.get(implKey));
-    context.onDefinition(ctx => ctx.whenReady(elementType => ctx.get(implKey).apply(elementType)));
+    context.forDefinitions({ provide: AttributeRegistry, provider: () => new AttributeRegistry() });
+    context.forDefinitions({ provide: AttributeRegistry_, provider: ctx => ctx.get(AttributeRegistry) });
+    context.onDefinition(ctx => ctx.whenReady(elementType => ctx.get(AttributeRegistry).apply(elementType)));
   },
 })
 export class AttributesSupport {}

--- a/src/features/attributes/attributes.decorator.ts
+++ b/src/features/attributes/attributes.decorator.ts
@@ -24,7 +24,7 @@ export function Attributes<
         {
           define(defContext) {
 
-            const registry = defContext.get(AttributeRegistry.key);
+            const registry = defContext.get(AttributeRegistry);
 
             Object.keys(opts).forEach(name => {
               registry.onAttributeChange(name, attributeStateUpdate(name, opts[name]));

--- a/src/features/dom-properties/dom-properties-support.feature.ts
+++ b/src/features/dom-properties/dom-properties-support.feature.ts
@@ -5,6 +5,8 @@ import { DomPropertyRegistry as DomPropertyRegistry_ } from './dom-property-regi
 
 class DomPropertyRegistry implements DomPropertyRegistry_ {
 
+  static readonly key = new SingleValueKey<DomPropertyRegistry>('dom-property-registry:impl');
+
   private readonly _props = new Map<PropertyKey, PropertyDescriptor>();
 
   domProperty(propertyKey: PropertyKey, descriptor: PropertyDescriptor): void {
@@ -19,8 +21,6 @@ class DomPropertyRegistry implements DomPropertyRegistry_ {
 
 }
 
-const implKey = new SingleValueKey<DomPropertyRegistry>('dom-property-registry:impl');
-
 /**
  * A feature adding properties to custom elements.
  *
@@ -28,10 +28,9 @@ const implKey = new SingleValueKey<DomPropertyRegistry>('dom-property-registry:i
  */
 @WesFeature({
   bootstrap(context) {
-    context.forDefinitions(implKey, () => new DomPropertyRegistry());
-    context.forDefinitions(DomPropertyRegistry_.key, ctx => ctx.get(implKey));
-    context.onDefinition(defContext =>
-        defContext.whenReady(elementType => defContext.get(implKey).apply(elementType)));
+    context.forDefinitions({ provide: DomPropertyRegistry, provider: () => new DomPropertyRegistry() });
+    context.forDefinitions({ provide: DomPropertyRegistry_, provider: ctx => ctx.get(DomPropertyRegistry) });
+    context.onDefinition(ctx => ctx.whenReady(elementType => ctx.get(DomPropertyRegistry).apply(elementType)));
   }
 })
 export class DomPropertiesSupport {}

--- a/src/features/dom-properties/dom-property.decorator.ts
+++ b/src/features/dom-properties/dom-property.decorator.ts
@@ -57,7 +57,7 @@ export function DomProperty<T extends ComponentClass>(opts: DomProperty.Opts<T> 
         componentType,
         {
           define(definitionContext) {
-            definitionContext.get(DomPropertyRegistry.key).domProperty(name, desc);
+            definitionContext.get(DomPropertyRegistry).domProperty(name, desc);
           }
         });
 

--- a/src/features/render/render-support.feature.spec.ts
+++ b/src/features/render/render-support.feature.spec.ts
@@ -2,7 +2,7 @@ import SpyObj = jasmine.SpyObj;
 import { bootstrapComponents } from '../../bootstrap';
 import { Class } from '../../common';
 import { ComponentClass, ComponentContext, CustomElements, WesComponent } from '../../component';
-import { BootstrapContext, WesFeature } from '../../feature';
+import { BootstrapWindow, WesFeature } from '../../feature';
 import { RenderScheduler } from './render-scheduler';
 import { RenderSupport } from './render-support.feature';
 
@@ -42,7 +42,7 @@ describe('features/render/render-support.feature', () => {
       @WesFeature({
         require: [RenderSupport, testComponent],
         prebootstrap: [
-          { provide: BootstrapContext.windowKey, value: windowSpy },
+          { provide: BootstrapWindow, value: windowSpy },
           { provide: CustomElements, value: customElementsSpy },
         ]
       })

--- a/src/features/render/render-support.feature.spec.ts
+++ b/src/features/render/render-support.feature.spec.ts
@@ -42,8 +42,8 @@ describe('features/render/render-support.feature', () => {
       @WesFeature({
         require: [RenderSupport, testComponent],
         prebootstrap: [
-          { key: BootstrapContext.windowKey, value: windowSpy },
-          { key: CustomElements.key, value: customElementsSpy },
+          { provide: BootstrapContext.windowKey, value: windowSpy },
+          { provide: CustomElements, value: customElementsSpy },
         ]
       })
       class TestFeature {}

--- a/src/features/render/render-support.feature.spec.ts
+++ b/src/features/render/render-support.feature.spec.ts
@@ -61,7 +61,7 @@ describe('features/render/render-support.feature', () => {
         const element = new elementType;
 
         componentContext = ComponentContext.of(element);
-        renderScheduler = componentContext.get(RenderScheduler.key);
+        renderScheduler = componentContext.get(RenderScheduler);
       });
 
       it('is available to component', () => {

--- a/src/features/render/render-support.feature.ts
+++ b/src/features/render/render-support.feature.ts
@@ -1,6 +1,6 @@
 import { noop } from '../../common';
 import { ComponentContext } from '../../component';
-import { BootstrapContext, WesFeature } from '../../feature';
+import { BootstrapWindow, WesFeature } from '../../feature';
 import { RenderScheduler as RenderScheduler_ } from './render-scheduler';
 
 /**
@@ -19,7 +19,7 @@ export class RenderSupport {
 function createRenderScheduler<T extends object>(ctx: ComponentContext<T>) {
 
   let scheduled: () => void = noop;
-  const window = ctx.get(BootstrapContext.windowKey);
+  const window = ctx.get(BootstrapWindow);
 
   class RenderScheduler extends RenderScheduler_ {
 

--- a/src/features/render/render-support.feature.ts
+++ b/src/features/render/render-support.feature.ts
@@ -10,7 +10,7 @@ import { RenderScheduler as RenderScheduler_ } from './render-scheduler';
  */
 @WesFeature({
   bootstrap(context) {
-    context.forComponents(RenderScheduler_.key, createRenderScheduler);
+    context.forComponents({ provide: RenderScheduler_, provider: createRenderScheduler });
   }
 })
 export class RenderSupport {

--- a/src/features/render/render.decorator.spec.ts
+++ b/src/features/render/render.decorator.spec.ts
@@ -51,8 +51,8 @@ describe('features/render/render.decorator', () => {
       @WesFeature({
         require: testComponent,
         prebootstrap: [
-          { key: RenderScheduler.key, value: renderSchedulerSpy },
-          { key: CustomElements.key, value: customElementsSpy },
+          { provide: RenderScheduler, value: renderSchedulerSpy },
+          { provide: CustomElements, value: customElementsSpy },
         ],
         provide: RenderSupport,
       })

--- a/src/features/render/render.decorator.ts
+++ b/src/features/render/render.decorator.ts
@@ -29,8 +29,8 @@ export function Render<T extends ComponentClass>(): TypedPropertyDecorator<T> {
               compContext.whenReady(() => {
 
                 const component = compContext.component as any;
-                const stateTracker = compContext.get(StateTracker.key);
-                const renderScheduler = compContext.get(RenderScheduler.key);
+                const stateTracker = compContext.get(StateTracker);
+                const renderScheduler = compContext.get(RenderScheduler);
 
                 stateTracker.onStateUpdate(() => {
                   renderScheduler.scheduleRender(() => component[propertyKey]());

--- a/src/features/shadow-dom/attach-shadow.decorator.spec.ts
+++ b/src/features/shadow-dom/attach-shadow.decorator.spec.ts
@@ -3,6 +3,7 @@ import { FeatureDef } from '../../feature';
 import { testElement } from '../../spec/test-element';
 import { list2set } from '../../util';
 import { AttachShadow } from './attach-shadow.decorator';
+import { ShadowContentRoot } from './shadow-content-root';
 import { ShadowDomSupport } from './shadow-dom-support.feature';
 import Spy = jasmine.Spy;
 
@@ -11,7 +12,7 @@ describe('features/shadow-dom/attach-shadow.decorator', () => {
 
     let testComponent: ComponentClass;
     let attachShadowSpy: Spy;
-    let shadowRoot: ShadowRoot;
+    let shadowRoot: ShadowContentRoot;
     let element: any;
     let context: ComponentContext;
 
@@ -42,7 +43,7 @@ describe('features/shadow-dom/attach-shadow.decorator', () => {
       expect(list2set(FeatureDef.of(testComponent).require)).toContain(ShadowDomSupport);
     });
     it('provides shadow root', () => {
-      expect(context.get(ShadowDomSupport.shadowRootKey)).toBe(shadowRoot);
+      expect(context.get(ShadowContentRoot)).toBe(shadowRoot);
     });
     it('provides shadow root as content root', () => {
       expect(context.contentRoot).toBe(shadowRoot);
@@ -93,7 +94,7 @@ describe('features/shadow-dom/attach-shadow.decorator', () => {
       element = new (testElement(OtherComponent))();
       context = ComponentContext.of(element);
 
-      expect(context.get(ShadowDomSupport.shadowRootKey)).toBe(element);
+      expect(context.get(ShadowContentRoot)).toBe(element);
     });
   });
 });

--- a/src/features/shadow-dom/attach-shadow.decorator.ts
+++ b/src/features/shadow-dom/attach-shadow.decorator.ts
@@ -20,12 +20,20 @@ export function AttachShadow<T extends ComponentClass<any> = any>(
         {
           define(this: ComponentClass<InstanceType<T>>, context: DefinitionContext<InstanceType<T>>) {
 
-            context.forComponents(
-                ShadowDomSupport.shadowRootKey,
-                ctx => ctx.get(ShadowRootBuilder.key)(ctx, init));
+            context.forComponents({
+              provide: ShadowDomSupport.shadowRootKey,
+              provider(ctx) {
+                return ctx.get(ShadowRootBuilder.key)(ctx, init);
+              },
+            });
 
             // Content root is an alias of shadow root.
-            context.forComponents(ComponentContext.contentRootKey, ctx => ctx.get(ShadowDomSupport.shadowRootKey));
+            context.forComponents({
+              provide: ComponentContext.contentRootKey,
+              provider(ctx) {
+                return ctx.get(ShadowDomSupport.shadowRootKey);
+              },
+            });
 
             // Attach shadow root eagerly on element instantiation.
             context.onComponent(ctx => ctx.get(ShadowDomSupport.shadowRootKey));

--- a/src/features/shadow-dom/attach-shadow.decorator.ts
+++ b/src/features/shadow-dom/attach-shadow.decorator.ts
@@ -1,5 +1,5 @@
 import { TypedClassDecorator } from '../../common';
-import { ComponentClass, ComponentContext, ComponentDef, DefinitionContext } from '../../component';
+import { ComponentClass, ComponentDef, ContentRoot, DefinitionContext } from '../../component';
 import { FeatureDef } from '../../feature';
 import { ShadowDomSupport } from './shadow-dom-support.feature';
 import { ShadowRootBuilder } from './shadow-root-builder';
@@ -29,7 +29,7 @@ export function AttachShadow<T extends ComponentClass<any> = any>(
 
             // Content root is an alias of shadow root.
             context.forComponents({
-              provide: ComponentContext.contentRootKey,
+              provide: ContentRoot,
               provider(ctx) {
                 return ctx.get(ShadowDomSupport.shadowRootKey);
               },

--- a/src/features/shadow-dom/attach-shadow.decorator.ts
+++ b/src/features/shadow-dom/attach-shadow.decorator.ts
@@ -1,6 +1,7 @@
 import { TypedClassDecorator } from '../../common';
 import { ComponentClass, ComponentDef, ContentRoot, DefinitionContext } from '../../component';
 import { FeatureDef } from '../../feature';
+import { ShadowContentRoot } from './shadow-content-root';
 import { ShadowDomSupport } from './shadow-dom-support.feature';
 import { ShadowRootBuilder } from './shadow-root-builder';
 
@@ -21,7 +22,7 @@ export function AttachShadow<T extends ComponentClass<any> = any>(
           define(this: ComponentClass<InstanceType<T>>, context: DefinitionContext<InstanceType<T>>) {
 
             context.forComponents({
-              provide: ShadowDomSupport.shadowRootKey,
+              provide: ShadowContentRoot,
               provider(ctx) {
                 return ctx.get(ShadowRootBuilder)(ctx, init);
               },
@@ -31,12 +32,12 @@ export function AttachShadow<T extends ComponentClass<any> = any>(
             context.forComponents({
               provide: ContentRoot,
               provider(ctx) {
-                return ctx.get(ShadowDomSupport.shadowRootKey);
+                return ctx.get(ShadowContentRoot);
               },
             });
 
             // Attach shadow root eagerly on element instantiation.
-            context.onComponent(ctx => ctx.get(ShadowDomSupport.shadowRootKey));
+            context.onComponent(ctx => ctx.get(ShadowContentRoot));
           }
         });
   };

--- a/src/features/shadow-dom/attach-shadow.decorator.ts
+++ b/src/features/shadow-dom/attach-shadow.decorator.ts
@@ -23,7 +23,7 @@ export function AttachShadow<T extends ComponentClass<any> = any>(
             context.forComponents({
               provide: ShadowDomSupport.shadowRootKey,
               provider(ctx) {
-                return ctx.get(ShadowRootBuilder.key)(ctx, init);
+                return ctx.get(ShadowRootBuilder)(ctx, init);
               },
             });
 

--- a/src/features/shadow-dom/index.ts
+++ b/src/features/shadow-dom/index.ts
@@ -1,3 +1,4 @@
 export * from './attach-shadow.decorator';
 export * from './shadow-dom-support.feature';
+export * from './shadow-content-root';
 export * from './shadow-root-builder';

--- a/src/features/shadow-dom/shadow-content-root.ts
+++ b/src/features/shadow-dom/shadow-content-root.ts
@@ -1,0 +1,17 @@
+import { ContextValueKey, SingleValueKey } from '../../common';
+
+/**
+ * Component shadow content root.
+ */
+export type ShadowContentRoot = ShadowRoot;
+
+export namespace ShadowContentRoot {
+
+  /**
+   * A key of component context value containing a shadow content root instance.
+   *
+   * This is only available when the component is decorated with `@AttachShadow` decorator.
+   */
+  export const key: ContextValueKey<ShadowContentRoot> = new SingleValueKey('shadow-root');
+
+}

--- a/src/features/shadow-dom/shadow-dom-support.feature.ts
+++ b/src/features/shadow-dom/shadow-dom-support.feature.ts
@@ -1,7 +1,6 @@
-import { ContextValueKey, SingleValueKey } from '../../common';
 import { ComponentContext } from '../../component';
 import { WesFeature } from '../../feature';
-import { ShadowRootBuilder as ShadowRootBuilder_ } from './shadow-root-builder';
+import { ShadowRootBuilder } from './shadow-root-builder';
 
 function attachShadow(context: ComponentContext, init: ShadowRootInit): ShadowRoot {
 
@@ -21,16 +20,7 @@ function attachShadow(context: ComponentContext, init: ShadowRootInit): ShadowRo
  */
 @WesFeature({
   prebootstrap: [
-    { provide: ShadowRootBuilder_, value: attachShadow },
+    { provide: ShadowRootBuilder, value: attachShadow },
   ],
 })
-export class ShadowDomSupport {
-
-  /**
-   * A key of component context value containing a shadow root instance.
-   *
-   * This is only available when the component is decorated with `@AttachShadow` decorator.
-   */
-  static readonly shadowRootKey: ContextValueKey<ShadowRoot> = new SingleValueKey('shadow-root');
-
-}
+export class ShadowDomSupport {}

--- a/src/features/shadow-dom/shadow-dom-support.feature.ts
+++ b/src/features/shadow-dom/shadow-dom-support.feature.ts
@@ -21,7 +21,7 @@ function attachShadow(context: ComponentContext, init: ShadowRootInit): ShadowRo
  */
 @WesFeature({
   prebootstrap: [
-    { key: ShadowRootBuilder_.key, value: attachShadow },
+    { provide: ShadowRootBuilder_, value: attachShadow },
   ],
 })
 export class ShadowDomSupport {

--- a/src/features/state/state-support.feature.ts
+++ b/src/features/state/state-support.feature.ts
@@ -20,21 +20,29 @@ export class StateSupport {
 }
 
 function enableStateSupport(context: BootstrapContext) {
-  context.forComponents(StateTracker_.key, () => {
+  context.forComponents({
+    provide: StateTracker_,
+    provider() {
 
-    const emitter = new EventEmitter<StateUpdater>();
+      const emitter = new EventEmitter<StateUpdater>();
 
-    class StateTracker extends StateTracker_ {
+      class StateTracker extends StateTracker_ {
 
-      readonly onStateUpdate = emitter.on;
+        readonly onStateUpdate = emitter.on;
 
-      readonly updateState: StateUpdater = <V>(key: StateValueKey, newValue: V, oldValue: V) => {
-        emitter.notify(key, newValue, oldValue);
+        readonly updateState: StateUpdater = <V>(key: StateValueKey, newValue: V, oldValue: V) => {
+          emitter.notify(key, newValue, oldValue);
+        }
+
       }
 
-    }
-
-    return new StateTracker();
+      return new StateTracker();
+    },
   });
-  context.forComponents(StateUpdater.key, ctx => ctx.get(StateTracker_.key).updateState);
+  context.forComponents({
+    provide: StateUpdater,
+    provider(ctx) {
+      return ctx.get(StateTracker_.key).updateState;
+    },
+  });
 }

--- a/src/features/state/state-support.feature.ts
+++ b/src/features/state/state-support.feature.ts
@@ -1,5 +1,4 @@
-import { EventEmitter, StateUpdateConsumer, StateValueKey } from '../../common';
-import { ComponentContext } from '../../component';
+import { EventEmitter, StateUpdater, StateValueKey } from '../../common';
 import { BootstrapContext, WesFeature } from '../../feature';
 import { StateTracker as StateTracker_ } from './state-tracker';
 
@@ -8,7 +7,7 @@ import { StateTracker as StateTracker_ } from './state-tracker';
  *
  * When enabled, it registers context values for each component with the following keys:
  *
- * - `[ComponentContext.stateUpdateKey]` that allows to update the component state, and
+ * - `[StateUpdater.key]` that allows to update the component state, and
  * - `[StateTracker.key]` containing a `StateTracker` instance to track the state changes.
  *
  * Other features would use this to notify when the state changes. E.g. `DomPropertiesSupport` and `AttributesSupport`
@@ -23,13 +22,13 @@ export class StateSupport {
 function enableStateSupport(context: BootstrapContext) {
   context.forComponents(StateTracker_.key, () => {
 
-    const emitter = new EventEmitter<StateUpdateConsumer>();
+    const emitter = new EventEmitter<StateUpdater>();
 
     class StateTracker extends StateTracker_ {
 
       readonly onStateUpdate = emitter.on;
 
-      readonly updateState: StateUpdateConsumer = <V>(key: StateValueKey, newValue: V, oldValue: V) => {
+      readonly updateState: StateUpdater = <V>(key: StateValueKey, newValue: V, oldValue: V) => {
         emitter.notify(key, newValue, oldValue);
       }
 
@@ -37,5 +36,5 @@ function enableStateSupport(context: BootstrapContext) {
 
     return new StateTracker();
   });
-  context.forComponents(ComponentContext.stateUpdateKey, ctx => ctx.get(StateTracker_.key).updateState);
+  context.forComponents(StateUpdater.key, ctx => ctx.get(StateTracker_.key).updateState);
 }

--- a/src/features/state/state-support.feature.ts
+++ b/src/features/state/state-support.feature.ts
@@ -42,7 +42,7 @@ function enableStateSupport(context: BootstrapContext) {
   context.forComponents({
     provide: StateUpdater,
     provider(ctx) {
-      return ctx.get(StateTracker_.key).updateState;
+      return ctx.get(StateTracker_).updateState;
     },
   });
 }

--- a/src/features/state/state-tracker.ts
+++ b/src/features/state/state-tracker.ts
@@ -1,4 +1,4 @@
-import { ContextValueKey, EventProducer, SingleValueKey, StateUpdateConsumer } from '../../common';
+import { ContextValueKey, EventProducer, SingleValueKey, StateUpdater } from '../../common';
 
 /**
  * Component state tracker.
@@ -21,14 +21,14 @@ export abstract class StateTracker {
    *
    * @return An event interest instance.
    */
-  abstract readonly onStateUpdate: EventProducer<StateUpdateConsumer>;
+  abstract readonly onStateUpdate: EventProducer<StateUpdater>;
 
   /**
    * Updates the component state.
    *
    * All listeners registered with `onStateUpdate()` will be notified on this update.
    *
-   * This method is also called by the function available under `[ComponentContext.stateUpdateKey]` key.
+   * This method is also called by the function available under `[StateUpdater.key]` key.
    * The latter is preferred way to call it, as the caller won't depend on `StateSupport` feature then.
    *
    * @param <V> A type of changed value.
@@ -36,6 +36,6 @@ export abstract class StateTracker {
    * @param newValue New value.
    * @param oldValue Previous value.
    */
-  abstract readonly updateState: StateUpdateConsumer;
+  abstract readonly updateState: StateUpdater;
 
 }

--- a/src/features/state/state-usage.spec.ts
+++ b/src/features/state/state-usage.spec.ts
@@ -1,4 +1,4 @@
-import { StateUpdateConsumer } from '../../common';
+import { StateUpdater } from '../../common';
 import { ComponentClass, ComponentContext, WesComponent } from '../../component';
 import { WesFeature } from '../../feature';
 import { TestBootstrap } from '../../spec/test-bootstrap';
@@ -11,7 +11,7 @@ describe('features/state', () => {
     let bootstrap: TestBootstrap;
     let testComponent: ComponentClass;
     let context: ComponentContext;
-    let updateState: StateUpdateConsumer;
+    let updateState: StateUpdater;
     let stateTracker: StateTracker;
 
     beforeEach(() => {
@@ -24,8 +24,8 @@ describe('features/state', () => {
       class TestComponent {
         constructor(ctx: ComponentContext) {
           context = ctx;
-          updateState = ctx.get(ComponentContext.stateUpdateKey);
-          stateTracker = ctx.get(StateTracker.key);
+          updateState = ctx.get(StateUpdater);
+          stateTracker = ctx.get(StateTracker);
         }
       }
 

--- a/src/spec/test-bootstrap.ts
+++ b/src/spec/test-bootstrap.ts
@@ -28,7 +28,7 @@ export class TestBootstrap {
     await this.iframe.create();
 
     @WesFeature({
-      prebootstrap: { key: BootstrapContext.windowKey, provider: () => this.window },
+      prebootstrap: { provide: BootstrapContext.windowKey, provider: () => this.window },
       bootstrap: ctx => this._context = ctx,
     })
     class TestFeature {}

--- a/src/spec/test-bootstrap.ts
+++ b/src/spec/test-bootstrap.ts
@@ -1,7 +1,7 @@
 import { bootstrapComponents } from '../bootstrap';
 import { Class } from '../common';
 import { Component, ComponentClass, ComponentDef } from '../component';
-import { BootstrapContext, WesFeature } from '../feature';
+import { BootstrapContext, BootstrapWindow, WesFeature } from '../feature';
 import { TestIframe } from './test-iframe';
 
 export class TestBootstrap {
@@ -28,7 +28,7 @@ export class TestBootstrap {
     await this.iframe.create();
 
     @WesFeature({
-      prebootstrap: { provide: BootstrapContext.windowKey, provider: () => this.window },
+      prebootstrap: { provide: BootstrapWindow, provider: () => this.window },
       bootstrap: ctx => this._context = ctx,
     })
     class TestFeature {}

--- a/src/spec/test-element.ts
+++ b/src/spec/test-element.ts
@@ -21,7 +21,7 @@ export function testElement(componentType: Class): Class<any> {
   };
 
   @WesFeature({
-    prebootstrap: { key: CustomElements.key, value: customElements },
+    prebootstrap: { provide: CustomElements, value: customElements },
     require: componentType,
   })
   class TestFeature {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,15 +30,15 @@
   dependencies:
     "@types/node" "*"
 
-"@types/jasmine@^2.8.8":
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.8.tgz#bf53a7d193ea8b03867a38bfdb4fbb0e0bf066c9"
-  integrity sha512-OJSUxLaxXsjjhob2DBzqzgrkLmukM3+JMpRp0r0E4HTdT1nwDCWhaswjYxazPij6uOdzHCJfNbDjmQ1/rnNbCg==
+"@types/jasmine@^2.8.9":
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.9.tgz#e028c891e8551fdf6de905d959581fc4fa0b5509"
+  integrity sha512-8dPZwjosElZOGGYw1nwTvOEMof4gjwAWNFS93nBI091BoEfd5drnHOLRMiRF/LOPuMTn5LgEdv0bTUO8QFVuHQ==
 
 "@types/node@*":
-  version "10.11.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.3.tgz#c055536ac8a5e871701aa01914be5731539d01ee"
-  integrity sha512-3AvcEJAh9EMatxs+OxAlvAEs7OTy6AG94mcH1iqyVDwVVndekLxzwkWQ/Z4SDbY6GO2oyUXyWW8tQ4rENSSQVQ==
+  version "10.11.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.6.tgz#ce5690df6cd917a9178439a1013e39a7e565c46e"
+  integrity sha512-fnA7yvqg3oKQDb3skBif9w5RRKVKAaeKeNuLzZL37XcSiWL4IoSXQnnbchR3UnBu2EMLHBip7ZVEkqoIVBP8QQ==
 
 abbrev@1:
   version "1.1.1"
@@ -752,9 +752,9 @@ combined-stream@~1.0.6:
     delayed-stream "~1.0.0"
 
 commander@^2.12.1:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
-  integrity sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
 commander@~2.17.1:
   version "2.17.1"
@@ -965,9 +965,9 @@ debug@^0.7.2:
   integrity sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=
 
 debug@^3.1.0:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.5.tgz#c2418fbfd7a29f4d4f70ff4cea604d4b64c46407"
-  integrity sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
 
@@ -1214,7 +1214,7 @@ estraverse@^1.9.1:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
   integrity sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=
 
-estree-walker@^0.5.1, estree-walker@^0.5.2:
+estree-walker@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.2.tgz#d3850be7529c9580d815600b53126515e146dd39"
   integrity sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==
@@ -1424,9 +1424,9 @@ find-up@^1.0.0:
     pinkie-promise "^2.0.0"
 
 follow-redirects@^1.0.0:
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.8.tgz#1dbfe13e45ad969f813e86c00e5296f525c885a1"
-  integrity sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==
+  version "1.5.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.9.tgz#c9ed9d748b814a39535716e531b9196a845d89c6"
+  integrity sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==
   dependencies:
     debug "=3.1.0"
 
@@ -2342,9 +2342,9 @@ log4js@^1.1.1:
     streamroller "^0.4.0"
 
 log4js@^3.0.0:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/log4js/-/log4js-3.0.5.tgz#b80146bfebad68b430d4f3569556d8a6edfef303"
-  integrity sha512-IX5c3G/7fuTtdr0JjOT2OIR12aTESVhsH6cEsijloYwKgcPRlO6DgOU72v0UFhWcoV1HN6+M3dwT89qVPLXm0w==
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/log4js/-/log4js-3.0.6.tgz#e6caced94967eeeb9ce399f9f8682a4b2b28c8ff"
+  integrity sha512-ezXZk6oPJCWL483zj64pNkMuY/NcRX5MPiB0zE6tjZM137aeusrOnW1ecxgF9cmwMWkBMhjteQxBPoZBh9FDxQ==
   dependencies:
     circular-json "^0.5.5"
     date-format "^1.2.0"
@@ -2365,12 +2365,12 @@ lru-cache@2.2.x:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
   integrity sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=
 
-magic-string@^0.22.4:
-  version "0.22.5"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.5.tgz#8e9cf5afddf44385c1da5bc2a6a0dbd10b03657e"
-  integrity sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==
+magic-string@^0.25.1:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.1.tgz#b1c248b399cd7485da0fe7385c2fc7011843266e"
+  integrity sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==
   dependencies:
-    vlq "^0.2.2"
+    sourcemap-codec "^1.4.1"
 
 map-cache@^0.2.2:
   version "0.2.2"
@@ -2395,12 +2395,13 @@ math-random@^1.0.1:
   integrity sha1-izqsWIuKZuSXXjzepn97sylgH6w=
 
 md5.js@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.4.tgz#e9bdbde94a20a5ac18b04340fc5764d5b09d901d"
-  integrity sha1-6b296UogpawYsENA/Fdk1bCdkB0=
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
+  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+    safe-buffer "^5.1.2"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -2655,9 +2656,9 @@ npm-bundled@^1.0.1:
   integrity sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==
 
 npm-packlist@^1.1.6:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.11.tgz#84e8c683cbe7867d34b1d357d893ce29e28a02de"
-  integrity sha512-CxKlZ24urLkJk+9kCm48RTQ7L4hsmgSVzEk0TLGPzzyuFxD7VNgy5Sl24tOLMzQv773a/NeJ1ce1DKeacqffEA==
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.12.tgz#22bde2ebc12e72ca482abd67afc51eb49377243a"
+  integrity sha512-WJKFOVMeAlsU/pjXuqVdzU0WfgtIBCupkEVwn+1Y0ERAbUfWw8R4GjgVbaKnUjRoD2FoQbHOCbOyT5Mbs9Lw4g==
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
@@ -3001,10 +3002,10 @@ punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-puppeteer@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.8.0.tgz#9e8bbd2f5448cc19cac220efc0512837104877ad"
-  integrity sha512-wJ7Fxs03l4dy/ZXQACUKBBobIuJaS4NHq44q7/QinpAXFMwJMJFEIPjzoksVzUhZxQe+RXnjXH69mg13yMh0BA==
+puppeteer@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.9.0.tgz#56dba79e7ea4faac807877bee3b23d63291fc59e"
+  integrity sha512-GH4PmhJf9wBRAPvtJkEJLAvdNNOofZortmBZSj8cGWYni98GUFqsf66blOEfJbo5B8l0KG5HR2d/W2MejnUrzg==
   dependencies:
     debug "^3.1.0"
     extract-zip "^1.6.6"
@@ -3248,7 +3249,7 @@ resolve@1.1.7, resolve@1.1.x:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.8.1, resolve@^1.1.6, resolve@^1.3.2, resolve@^1.5.0:
+resolve@1.8.1, resolve@^1.1.6, resolve@^1.3.2, resolve@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
@@ -3280,15 +3281,15 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup-plugin-commonjs@^9.1.8:
-  version "9.1.8"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.1.8.tgz#4113ed94e6054b5f8a3501d8811f934cadde3246"
-  integrity sha512-c3nAfVVyEwbq9OohIeQudfQQdGV9Cl1RE8MUc90fH9UdtCiWAYpI+au3HxGwNf1DdV51HfBjCDbT4fwjsZEUUg==
+rollup-plugin-commonjs@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.2.0.tgz#4604e25069e0c78a09e08faa95dc32dec27f7c89"
+  integrity sha512-0RM5U4Vd6iHjL6rLvr3lKBwnPsaVml+qxOGaaNUWN1lSq6S33KhITOfHmvxV3z2vy9Mk4t0g4rNlVaJJsNQPWA==
   dependencies:
-    estree-walker "^0.5.1"
-    magic-string "^0.22.4"
-    resolve "^1.5.0"
-    rollup-pluginutils "^2.0.1"
+    estree-walker "^0.5.2"
+    magic-string "^0.25.1"
+    resolve "^1.8.1"
+    rollup-pluginutils "^2.3.3"
 
 rollup-plugin-node-resolve@^3.4.0:
   version "3.4.0"
@@ -3317,14 +3318,14 @@ rollup-plugin-terser@^3.0.0:
     serialize-javascript "^1.5.0"
     terser "^3.8.2"
 
-rollup-plugin-typescript2@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.17.0.tgz#a540eecfe9ad8ff5e8e86eaf5069bb2a7f84f33a"
-  integrity sha512-QB6Ii+HVAdmNwjlCay7gLrddoNtquLT4cECg7wynK3XQ9k6ebsd1Km09Tbpcm+WHBjMZqeDZGFmzny57NTfkmg==
+rollup-plugin-typescript2@^0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.17.1.tgz#298099f372270ae3f41fa63188400c3df2dbdb2b"
+  integrity sha512-WZJ220IID2UJm3P15zIWQR6vi6YekRsL4irXYq/C9JHg+j9rqQOsihzXQM644LMgtwS3NUWKegbCOhUlCO7hKQ==
   dependencies:
     fs-extra "7.0.0"
     resolve "1.8.1"
-    rollup-pluginutils "2.3.1"
+    rollup-pluginutils "2.3.3"
     tslib "1.9.3"
 
 rollup-plugin-uglify@^6.0.0:
@@ -3337,15 +3338,7 @@ rollup-plugin-uglify@^6.0.0:
     serialize-javascript "^1.5.0"
     uglify-js "^3.4.9"
 
-rollup-pluginutils@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.1.tgz#760d185ccc237dedc12d7ae48c6bcd127b4892d0"
-  integrity sha512-JZS8aJMHEHhqmY2QVPMXwKP6lsD1ShkrcGYjhAIvqKKdXQyPHw/9NF0tl3On/xOJ4ACkxfeG7AF+chfCN1NpBg==
-  dependencies:
-    estree-walker "^0.5.2"
-    micromatch "^2.3.11"
-
-rollup-pluginutils@^2.0.1:
+rollup-pluginutils@2.3.3, rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz#3aad9b1eb3e7fe8262820818840bf091e5ae6794"
   integrity sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA==
@@ -3353,10 +3346,10 @@ rollup-pluginutils@^2.0.1:
     estree-walker "^0.5.2"
     micromatch "^2.3.11"
 
-rollup@^0.66.2:
-  version "0.66.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.66.2.tgz#77acdb9f4093f5f035ce75480577c40a81ea7999"
-  integrity sha512-+rOLjWO170M3Y2jyyGU4ZJuTu1T1KuKNyH+RszHRzQdsuI5TulRbkSM4vlaMnwcxHm4XdgBNZ1mmNzhQIImbiQ==
+rollup@^0.66.5:
+  version "0.66.5"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.66.5.tgz#49b109d3db4772301d84b8ed9617a4481e9a8042"
+  integrity sha512-tFdxC5zOynOS3fUHkJmKk9QjRWVLXxDCUVDmpoZazubxgXZmS/XzrlzhwuOKPelJm92Hd4hmXIqkzVN22Isf+w==
   dependencies:
     "@types/estree" "0.0.39"
     "@types/node" "*"
@@ -3558,10 +3551,15 @@ source-map@~0.2.0:
   dependencies:
     amdefine ">=0.0.4"
 
+sourcemap-codec@^1.4.1:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.3.tgz#0ba615b73ec35112f63c2f2d9e7c3f87282b0e33"
+  integrity sha512-vFrY/x/NdsD7Yc8mpTJXuao9S8lq08Z/kOITHz6b7YbfI9xL8Spe5EvSQUHOI7SbpY8bRPr0U3kKSsPuqEGSfA==
+
 spdx-correct@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.1.tgz#434434ff9d1726b4d9f4219d1004813d80639e30"
-  integrity sha512-hxSPZbRZvSDuOvADntOElzJpenIR7wXJkuoUcUtS0erbgt2fgeaoPIYretfKpslMhfFDY4k0MZ2F5CUzhBsSvQ==
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.2.tgz#19bb409e91b47b1ad54159243f7312a858db3c2e"
+  integrity sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==
   dependencies:
     spdx-expression-parse "^3.0.0"
     spdx-license-ids "^3.0.0"
@@ -3764,9 +3762,9 @@ tar@^4:
     yallist "^3.0.2"
 
 terser@^3.8.2:
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-3.9.2.tgz#d139d8292eb3a23091304c934fb539d9f456fb19"
-  integrity sha512-zOaL2PwflERZkVWbzv8rGbDR493fUaD/KXIUz/vjuvyH6Cxwu4pitM6con3Jy4bWtcQJwNOvN4rHltFeTEwZQA==
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-3.10.0.tgz#6ae15dafecbd02c9788d5f36d27fca32196b533a"
+  integrity sha512-hNh2WR3YxtKoY7BNSb3+CJ9Xv9bbUuOU9uriIf2F1tiAYNA4rNy2wWuSDV8iKcag27q65KPJ/sPpMWEh6qttgw==
   dependencies:
     commander "~2.17.1"
     source-map "~0.6.1"
@@ -3916,10 +3914,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.1.tgz#3362ba9dd1e482ebb2355b02dfe8bcd19a2c7c96"
-  integrity sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==
+typescript@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.2.tgz#c03a5d16f30bb60ad8bb6fe8e7cb212eedeec950"
+  integrity sha512-gOoGJWbNnFAfP9FlrSV63LYD5DJqYJHG5ky1kOXSl3pCImn4rqWy/flyq1BRd4iChQsoCqjbQaqtmXO4yCVPCA==
 
 uglify-js@^3.1.4, uglify-js@^3.4.9:
   version "3.4.9"
@@ -4043,11 +4041,6 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
-
-vlq@^0.2.2:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
-  integrity sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==
 
 vm-browserify@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
Refine context value API.

Now the values can be accessed with `context.get(MyService)` instead of `context.get(MyService.key)`.
Also, the values are always provided with specifiers like `context.forComponents({ provide: MyService, provider: () => new MyService() })`