### PR TITLE
Specify self class of context value in `as` property

### DIFF
--- a/src/common/context/context-value-provider.spec.ts
+++ b/src/common/context/context-value-provider.spec.ts
@@ -118,10 +118,10 @@ describe('common/context/context-value-provider', () => {
         });
         it('converts self class to provider', () => {
 
-          const spec: ContextValueSpec.SelfInstance<ContextValues, Value> = { a: Value };
+          const spec: ContextValueSpec.SelfInstance<ContextValues, Value> = { as: Value };
           const def = ContextValueSpec.of(spec);
 
-          expect(def.a).toBe(spec.a);
+          expect(def.a).toBe(spec.as);
           expect(def.by(contextSpy)).toEqual(jasmine.any(Value));
           expect(constructorSpy).toHaveBeenCalledWith(contextSpy);
         });
@@ -160,7 +160,7 @@ describe('common/context/context-value-provider', () => {
           const key1 = new SingleContextKey<string>('arg1');
           const key2 = new SingleContextKey<number>('arg2');
           const spec: ContextValueSpec.SelfInstanceWithDeps<[string, number], Value> = {
-            a: Value,
+            as: Value,
             with: [key1, key2],
           };
           const def = ContextValueSpec.of(spec);
@@ -178,7 +178,7 @@ describe('common/context/context-value-provider', () => {
             return;
           });
 
-          expect(def.a).toBe(spec.a);
+          expect(def.a).toBe(spec.as);
           expect(def.by(contextSpy)).toEqual(jasmine.any(Value));
           expect(constructorSpy).toHaveBeenCalledWith(arg1, arg2);
           expect(contextSpy.get).toHaveBeenCalledWith(key1);

--- a/src/features/attributes/attributes-support.feature.ts
+++ b/src/features/attributes/attributes-support.feature.ts
@@ -45,7 +45,7 @@ class AttributeRegistry<T extends object> {
  */
 @Feature({
   bootstrap(context) {
-    context.forDefinitions({ a: AttributeRegistry });
+    context.forDefinitions({ as: AttributeRegistry });
     context.forDefinitions({
       a: AttributeRegistrar,
       by(registry: AttributeRegistry<any>) {

--- a/src/features/dom-properties/dom-properties-support.feature.ts
+++ b/src/features/dom-properties/dom-properties-support.feature.ts
@@ -29,7 +29,7 @@ class DomPropertyRegistry {
  */
 @Feature({
   bootstrap(context) {
-    context.forDefinitions({ a: DomPropertyRegistry });
+    context.forDefinitions({ as: DomPropertyRegistry });
     context.forDefinitions({
       a: DomPropertyRegistrar,
       by(registry: DomPropertyRegistry) {

--- a/src/features/state/state-support.feature.ts
+++ b/src/features/state/state-support.feature.ts
@@ -19,7 +19,7 @@ export class StateSupport {
 }
 
 function enableStateSupport(context: BootstrapContext) {
-  context.forComponents({ a: StateTracker });
+  context.forComponents({ as: StateTracker });
   context.forComponents({
     a: StateUpdater,
     by(tracker: StateTracker) {


### PR DESCRIPTION
To avoid incompatibility issues with `a` property.