### PR TITLE
 Introduce `ComponentEventProducer`

### DIFF
--- a/src/component/component-context.key.ts
+++ b/src/component/component-context.key.ts
@@ -1,0 +1,7 @@
+import { ContextKey, SingleContextKey } from 'context-values';
+import { ComponentContext } from './component-context';
+
+/**
+ * @internal
+ */
+export const componentContextKey: ContextKey<ComponentContext<any>> = new SingleContextKey('component-context');

--- a/src/component/component-context.ts
+++ b/src/component/component-context.ts
@@ -1,13 +1,11 @@
-import { ContextKey, ContextValues, SingleContextKey } from 'context-values';
+import { ContextValues } from 'context-values';
 import { EventProducer, StatePath, StateUpdater } from 'fun-events';
 import { bootstrapContextKey } from '../kit/bootstrap-context.key';
 import { ComponentClass } from './component-class';
+import { componentContextKey } from './component-context.key';
+import { componentEventDispatcherKey } from './component-event.key';
 import { ComponentMount } from './component-mount';
-
-const componentContextKey: ContextKey<ComponentContext<any>> = new SingleContextKey('component-context');
-const contentRootKey: ContextKey<ContentRoot> = new SingleContextKey(
-    'content-root',
-    ctx => ctx.get(componentContextKey).element);
+import { contentRootKey } from './content-root.key';
 
 /**
  * Component context.
@@ -164,45 +162,7 @@ export abstract class ComponentContext<T extends object = object> extends Contex
    * @param event An event to dispatch.
    */
   dispatchEvent(event: Event): void {
-    // tslint:disable-next-line:no-use-before-declare
-    this.get(bootstrapContextKey).get(ComponentEventDispatcher)(this, event);
+    this.get(bootstrapContextKey).get(componentEventDispatcherKey)(this, event);
   }
-
-}
-
-/**
- * Component content root node.
- */
-export type ContentRoot = ParentNode;
-
-export namespace ContentRoot {
-
-  /**
-   * A key of component context value containing a component root element.
-   *
-   * This is an element itself by default. But can be overridden e.g. by `@AttachShadow` decorator.
-   */
-  export const key = contentRootKey;
-
-}
-
-/**
- * Component event dispatcher function is used to dispatch component events.
- *
- * It is available in bootstrap context context.
- *
- * @param context A context of component to dispatch an `event` for.
- * @param event An event to dispatch.
- */
-export type ComponentEventDispatcher = (context: ComponentContext<any>, event: Event) => void;
-
-export namespace ComponentEventDispatcher {
-
-  /**
-   * A key of bootstrap context value containing component event dispatcher.
-   */
-  export const key: ContextKey<ComponentEventDispatcher> = new SingleContextKey(
-      'component-event-dispatcher',
-      () => (context: ComponentContext<any>, event: Event) => context.element.dispatchEvent(event));
 
 }

--- a/src/component/component-context.ts
+++ b/src/component/component-context.ts
@@ -1,9 +1,9 @@
 import { ContextValues } from 'context-values';
-import { EventProducer, StatePath, StateUpdater } from 'fun-events';
+import { DomEventDispatcher, DomEventProducer, EventProducer, StatePath, StateUpdater } from 'fun-events';
 import { bootstrapContextKey } from '../kit/bootstrap-context.key';
 import { ComponentClass } from './component-class';
 import { componentContextKey } from './component-context.key';
-import { componentEventDispatcherKey } from './component-event.key';
+import { componentEventDispatcherKey, componentEventProducerKey } from './component-event.key';
 import { ComponentMount } from './component-mount';
 import { contentRootKey } from './content-root.key';
 
@@ -152,6 +152,20 @@ export abstract class ComponentContext<T extends object = object> extends Contex
    * @param key Target property key.
    */
   abstract elementSuper(key: PropertyKey): any;
+
+  /**
+   * Returns a DOM event producer for the given event type.
+   *
+   * This is a shorthand for invoking a component event producer function available under
+   * `[ComponentEventProducer.key]` key.
+   *
+   * @param type An event type to listen for.
+   *
+   * @returns A producer of DOM event events of the given type.
+   */
+  on<E extends Event>(type: string): DomEventProducer<E> {
+    return this.get(componentEventProducerKey)(type);
+  }
 
   /**
    * Dispatches an event to component element.

--- a/src/component/component-def.ts
+++ b/src/component/component-def.ts
@@ -92,7 +92,7 @@ export namespace ComponentDef {
 
             const merged: PartialComponentDef<T> = { ...prev, ...def };
             const set = new ArraySet(prev.set).merge(def.set);
-            const newDefine = mergeFunctions<[DefinitionContext<T>], void, Class<T>>(prev.define, def.define);
+            const newDefine = mergeFunctions(prev.define, def.define);
             const forComponents = new ArraySet(prev.forComponents).merge(def.forComponents);
 
             if (set.size) {

--- a/src/component/component-event.key.ts
+++ b/src/component/component-event.key.ts
@@ -1,0 +1,10 @@
+import { ContextKey, SingleContextKey } from 'context-values';
+import { ComponentContext } from './component-context';
+import { ComponentEventDispatcher } from './component-event';
+
+/**
+ * @internal
+ */
+export const componentEventDispatcherKey: ContextKey<ComponentEventDispatcher> = new SingleContextKey(
+    'component-event-dispatcher',
+    () => (context: ComponentContext<any>, event: Event) => context.element.dispatchEvent(event));

--- a/src/component/component-event.key.ts
+++ b/src/component/component-event.key.ts
@@ -1,10 +1,24 @@
-import { ContextKey, SingleContextKey } from 'context-values';
+import { ContextValues, SingleContextKey } from 'context-values';
+import { DomEventDispatcher } from 'fun-events';
 import { ComponentContext } from './component-context';
-import { ComponentEventDispatcher } from './component-event';
+import { componentContextKey } from './component-context.key';
+import { ComponentEventDispatcher, ComponentEventProducer } from './component-event';
 
 /**
  * @internal
  */
-export const componentEventDispatcherKey: ContextKey<ComponentEventDispatcher> = new SingleContextKey(
+export const componentEventDispatcherKey = new SingleContextKey<ComponentEventDispatcher>(
     'component-event-dispatcher',
     () => (context: ComponentContext<any>, event: Event) => context.element.dispatchEvent(event));
+
+/**
+ * @internal
+ */
+export const componentEventProducerKey = new SingleContextKey<ComponentEventProducer>(
+    'component-event-producer',
+    (values: ContextValues) => {
+
+      const dispatcher = new DomEventDispatcher(values.get(componentContextKey).element);
+
+      return <E extends Event>(type: string) => dispatcher.on(type);
+    });

--- a/src/component/component-event.ts
+++ b/src/component/component-event.ts
@@ -1,4 +1,6 @@
+import { ContextKey } from 'context-values';
 import { ComponentContext } from './component-context';
+import { componentEventDispatcherKey } from './component-event.key';
 
 /**
  * Component event.
@@ -30,5 +32,24 @@ export class ComponentEvent extends Event {
   constructor(type: string, eventInitDict?: EventInit) {
     super(type, eventInitDict);
   }
+
+}
+
+/**
+ * Component event dispatcher function is used to dispatch component events.
+ *
+ * It is available in bootstrap context context.
+ *
+ * @param context A context of component to dispatch an `event` for.
+ * @param event An event to dispatch.
+ */
+export type ComponentEventDispatcher = (context: ComponentContext<any>, event: Event) => void;
+
+export namespace ComponentEventDispatcher {
+
+  /**
+   * A key of bootstrap context value containing component event dispatcher.
+   */
+  export const key: ContextKey<ComponentEventDispatcher> = componentEventDispatcherKey;
 
 }

--- a/src/component/component-event.ts
+++ b/src/component/component-event.ts
@@ -1,6 +1,7 @@
 import { ContextKey } from 'context-values';
+import { DomEventProducer } from 'fun-events';
 import { ComponentContext } from './component-context';
-import { componentEventDispatcherKey } from './component-event.key';
+import { componentEventDispatcherKey, componentEventProducerKey } from './component-event.key';
 
 /**
  * Component event.
@@ -51,5 +52,28 @@ export namespace ComponentEventDispatcher {
    * A key of bootstrap context value containing component event dispatcher.
    */
   export const key: ContextKey<ComponentEventDispatcher> = componentEventDispatcherKey;
+
+}
+
+/**
+ * A producer of DOM component events is a function accepting event type as its only argument and returning DOM event
+ * producer for that event type.
+ *
+ * It is available in each component context.
+ *
+ * By default treats a component element as event target.
+ *
+ * @param type An event type to listen for.
+ *
+ * @returns A producer of DOM event events of the given type.
+ */
+export type ComponentEventProducer = <E extends Event>(type: string) => DomEventProducer<E>;
+
+export namespace ComponentEventProducer {
+
+  /**
+   * A key of component context value containing component event producer.
+   */
+  export const key: ContextKey<ComponentEventProducer> = componentEventProducerKey;
 
 }

--- a/src/component/content-root.key.ts
+++ b/src/component/content-root.key.ts
@@ -1,0 +1,10 @@
+import { ContextKey, SingleContextKey } from 'context-values';
+import { componentContextKey } from './component-context.key';
+import { ContentRoot } from './content-root';
+
+/**
+ * @internal
+ */
+export const contentRootKey: ContextKey<ContentRoot> = new SingleContextKey(
+    'content-root',
+    ctx => ctx.get(componentContextKey).element);

--- a/src/component/content-root.ts
+++ b/src/component/content-root.ts
@@ -1,0 +1,18 @@
+import { ContextKey } from 'context-values';
+import { contentRootKey } from './content-root.key';
+
+export type ContentRoot = ParentNode;
+
+/**
+ * Component content root node.
+ */
+export namespace ContentRoot {
+
+  /**
+   * A key of component context value containing a component root element.
+   *
+   * This is an element itself by default. But can be overridden e.g. by `@AttachShadow` decorator.
+   */
+  export const key: ContextKey<ContentRoot> = contentRootKey;
+
+}

--- a/src/component/definition/definition-context.key.ts
+++ b/src/component/definition/definition-context.key.ts
@@ -1,0 +1,7 @@
+import { SingleContextKey } from 'context-values';
+import { DefinitionContext } from './definition-context';
+
+/**
+ * @internal
+ */
+export const definitionContextKey = new SingleContextKey<DefinitionContext<any>>('definition-context');

--- a/src/component/definition/definition-context.ts
+++ b/src/component/definition/definition-context.ts
@@ -1,10 +1,9 @@
-import { ContextKey, ContextValues, ContextValueSpec, SingleContextKey } from 'context-values';
+import { ContextKey, ContextValues, ContextValueSpec } from 'context-values';
 import { EventProducer } from 'fun-events';
 import { Class } from '../../common';
-import { BootstrapWindow } from '../../kit';
 import { ComponentClass } from '../component-class';
 import { ComponentContext } from '../component-context';
-import { ComponentDef } from '../component-def';
+import { definitionContextKey } from './definition-context.key';
 
 /**
  * Component definition context.
@@ -19,7 +18,7 @@ export abstract class DefinitionContext<T extends object = object> extends Conte
   /**
    * A key of definition context value containing the definition context itself.
    */
-  static readonly key: ContextKey<DefinitionContext<any>> = new SingleContextKey('definition-context');
+  static readonly key: ContextKey<DefinitionContext<any>> = definitionContextKey;
 
   /**
    * Component class constructor.
@@ -66,32 +65,5 @@ export abstract class DefinitionContext<T extends object = object> extends Conte
    * @param spec Component context value specifier.
    */
   abstract forComponents<S>(spec: ContextValueSpec<ComponentContext<T>, any, any[], S>): void;
-
-}
-
-/**
- * Base element class constructor.
- */
-export type ElementBaseClass<T extends object = object> = Class<T>;
-
-export namespace ElementBaseClass {
-
-  /**
-   * A key of definition context value containing a base element class constructor.
-   *
-   * This value is the class the custom elements are inherited from.
-   *
-   * Target value defaults to `HTMLElement` from the window provided under `[BootstrapWindow.key]`,
-   * unless `ComponentDef.extend.type` is specified.
-   */
-  export const key = new SingleContextKey<ElementBaseClass>(
-      'element-base-class',
-      values => {
-
-        const componentType = values.get(DefinitionContext).componentType;
-        const extend = ComponentDef.of(componentType).extend;
-
-        return extend && extend.type ||  (values.get(BootstrapWindow) as any).HTMLElement;
-      });
 
 }

--- a/src/component/definition/element-base-class.key.ts
+++ b/src/component/definition/element-base-class.key.ts
@@ -1,0 +1,18 @@
+import { SingleContextKey } from 'context-values';
+import { BootstrapWindow } from '../../kit';
+import { ComponentDef } from '../component-def';
+import { definitionContextKey } from './definition-context.key';
+import { ElementBaseClass } from './element-base-class';
+
+/**
+ * @internal
+ */
+export const elementBaseClassKey = new SingleContextKey<ElementBaseClass>(
+    'element-base-class',
+    values => {
+
+      const componentType = values.get(definitionContextKey).componentType;
+      const extend = ComponentDef.of(componentType).extend;
+
+      return extend && extend.type ||  (values.get(BootstrapWindow) as any).HTMLElement;
+    });

--- a/src/component/definition/element-base-class.ts
+++ b/src/component/definition/element-base-class.ts
@@ -1,0 +1,22 @@
+import { ContextKey } from 'context-values';
+import { Class } from '../../common';
+import { elementBaseClassKey } from './element-base-class.key';
+
+/**
+ * Base element class constructor.
+ */
+export type ElementBaseClass<T extends object = object> = Class<T>;
+
+export namespace ElementBaseClass {
+
+  /**
+   * A key of definition context value containing a base element class constructor.
+   *
+   * This value is the class the custom elements are inherited from.
+   *
+   * Target value defaults to `HTMLElement` from the window provided under `[BootstrapWindow.key]`,
+   * unless `ComponentDef.extend.type` is specified.
+   */
+  export const key: ContextKey<ElementBaseClass> = elementBaseClassKey;
+
+}

--- a/src/component/definition/index.ts
+++ b/src/component/definition/index.ts
@@ -1,3 +1,4 @@
 export * from './component-factory';
 export * from './custom-elements';
 export * from './definition-context';
+export * from './element-base-class';

--- a/src/component/index.ts
+++ b/src/component/index.ts
@@ -4,3 +4,4 @@ export * from './component-context';
 export * from './component-def';
 export * from './component-event';
 export * from './component-mount';
+export * from './content-root';

--- a/src/kit/bootstrap-context.key.ts
+++ b/src/kit/bootstrap-context.key.ts
@@ -1,4 +1,7 @@
 import { ContextKey, SingleContextKey } from 'context-values';
 import { BootstrapContext } from './bootstrap-context';
 
+/**
+ * @internal
+ */
 export const bootstrapContextKey: ContextKey<BootstrapContext> = new SingleContextKey('bootstrap-context');

--- a/src/kit/definition/element-builder.spec.ts
+++ b/src/kit/definition/element-builder.spec.ts
@@ -199,11 +199,20 @@ describe('kit/definition/element-builder', () => {
           }
         });
       });
+
+      let addEventListenerSpy: Mock;
+      let removeEventListenerSpy: Mock;
+
       beforeEach(() => {
+        addEventListenerSpy = jest.fn();
+        removeEventListenerSpy = jest.fn();
         ComponentDef.define(
             TestComponent, {
               extend: {
-                type: Object,
+                type: class {
+                  addEventListener = addEventListenerSpy;
+                  removeEventListener = removeEventListenerSpy;
+                },
               },
               forComponents: { a: key2, is: value2, }
             });
@@ -232,6 +241,19 @@ describe('kit/definition/element-builder', () => {
           cancelable: false,
           bubbles: true,
         }));
+      });
+      it('allows to listen for component events', () => {
+
+        const listener = jest.fn().mockName('event listener');
+        const interest = componentContext.on('test-event')(listener);
+
+        expect(addEventListenerSpy).toHaveBeenCalledWith('test-event', expect.any(Function), undefined);
+
+        const actualListener = addEventListenerSpy.mock.calls[0][1];
+
+        interest.off();
+
+        expect(removeEventListenerSpy).toHaveBeenCalledWith('test-event', actualListener);
       });
       it('can not access values of another component type', () => {
 


### PR DESCRIPTION
Responsible for registering component event listeners.
Also available as `ComponentContext.on()` method.