### PR TITLE
Optional component name

### DIFF
--- a/src/component/component-def.spec.ts
+++ b/src/component/component-def.spec.ts
@@ -4,7 +4,7 @@ import { FeatureDef } from '../feature';
 import { BootstrapContext } from '../kit';
 import { ObjectMock } from '../spec/mocks';
 import { ComponentClass } from './component-class';
-import { ComponentDef, PartialComponentDef } from './component-def';
+import { ComponentDef } from './component-def';
 import { DefinitionContext } from './definition';
 
 describe('component/component-def', () => {
@@ -20,12 +20,12 @@ describe('component/component-def', () => {
 
         expect(ComponentDef.of(TestComponent)).toEqual(TestComponent[ComponentDef.symbol]);
       });
-      it('fails when there is no component definition', () => {
+      it('returns empty definition when absent', () => {
 
         class TestComponent {
         }
 
-        expect(() => ComponentDef.of(TestComponent)).toThrow(TypeError);
+        expect(ComponentDef.of(TestComponent)).toEqual({});
       });
       it('requests inherited definition', () => {
 
@@ -70,6 +70,7 @@ describe('component/component-def', () => {
         expect(ComponentDef.merge({ name: 'name1' }, { name: 'name2' })).toEqual({ name: 'name2' });
         expect(ComponentDef.merge({ name: 'name1' }, {})).toEqual({ name: 'name1' });
         expect(ComponentDef.merge({}, { name: 'name2' })).toEqual({ name: 'name2' });
+        expect(ComponentDef.merge({ name: 'name1' }, { name: undefined })).toEqual({ name: undefined });
       });
       it('merges `extend`', () => {
 
@@ -166,7 +167,7 @@ describe('component/component-def', () => {
 
         ComponentDef.define(TestComponent, initialDef);
 
-        const def: PartialComponentDef = {
+        const def: ComponentDef = {
           extend: {
             name: 'span',
             type: Base,
@@ -174,7 +175,7 @@ describe('component/component-def', () => {
         };
         const componentType = ComponentDef.define(TestComponent, def);
 
-        expect<PartialComponentDef>(ComponentDef.of(componentType)).toEqual(ComponentDef.merge(initialDef, def));
+        expect<ComponentDef>(ComponentDef.of(componentType)).toEqual(ComponentDef.merge(initialDef, def));
       });
       describe('created component feature', () => {
         it('registers the component', () => {

--- a/src/component/definition/custom-elements.spec.ts
+++ b/src/component/definition/custom-elements.spec.ts
@@ -58,6 +58,22 @@ describe('kit/custom-elements', () => {
 
         expect(registrySpy.define).toHaveBeenCalledWith('test-component', elementType);
       });
+      it('defines non-component custom element', () => {
+        customElements.define('test-component', elementType);
+
+        expect(registrySpy.define).toHaveBeenCalledWith('test-component', elementType);
+      });
+      it('does not define custom element for anonymous component', () => {
+
+        class AnonymousComponent {
+        }
+
+        ComponentDef.define(AnonymousComponent);
+
+        customElements.define(AnonymousComponent, elementType);
+
+        expect(registrySpy.define).not.toHaveBeenCalled();
+      });
       it('defines custom element extending another one', () => {
 
         class BaseElement {
@@ -102,6 +118,26 @@ describe('kit/custom-elements', () => {
 
         expect(customElements.whenDefined(TestComponent)).toBe(promise);
         expect(registrySpy.whenDefined).toHaveBeenCalledWith('test-component');
+      });
+      it('awaits for non-component element definition', () => {
+
+        const promise = Promise.resolve<any>('defined');
+
+        registrySpy.whenDefined.mockReturnValue(promise);
+
+        expect(customElements.whenDefined('test-component')).toBe(promise);
+        expect(registrySpy.whenDefined).toHaveBeenCalledWith('test-component');
+      });
+      it('does not wait for anonymous component definition', async () => {
+
+        class AnonymousComponent {
+        }
+
+        ComponentDef.define(AnonymousComponent);
+
+        await customElements.whenDefined(AnonymousComponent);
+
+        expect(registrySpy.whenDefined).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/component/definition/custom-elements.ts
+++ b/src/component/definition/custom-elements.ts
@@ -27,9 +27,18 @@ export abstract class CustomElements {
 
         class WindowCustomElements extends CustomElements {
 
-          define(componentType: ComponentClass, elementType: Class): void {
+          define(componentTypeOrName: ComponentClass<any> | string, elementType: Class): void {
+            if (typeof componentTypeOrName === 'string') {
+              customElements.define(componentTypeOrName, elementType);
+              return;
+            }
 
-            const def = ComponentDef.of(componentType);
+            const def = ComponentDef.of(componentTypeOrName);
+
+            if (!def.name) {
+              return; // Anonymous component.
+            }
+
             const ext = def.extend;
 
             if (ext && ext.name) {
@@ -44,9 +53,16 @@ export abstract class CustomElements {
             }
           }
 
-          whenDefined(componentType: ComponentClass): Promise<void> {
+          whenDefined(componentTypeOrName: ComponentClass<any> | string): Promise<void> {
+            if (typeof componentTypeOrName === 'string') {
+              return customElements.whenDefined(componentTypeOrName);
+            }
 
-            const def = ComponentDef.of(componentType);
+            const def = ComponentDef.of(componentTypeOrName);
+
+            if (!def.name) {
+              return Promise.resolve();
+            }
 
             return customElements.whenDefined(def.name);
           }
@@ -59,22 +75,22 @@ export abstract class CustomElements {
   /**
    * Defines custom element.
    *
-   * @param componentType A component class constructor.
-   * @param elementType A constructor of custom element class defined for `componentType`.
+   * @param componentTypeOrName A component class constructor or custom element name.
+   * @param elementType A constructor of custom element to define.
    */
-  abstract define(componentType: ComponentClass<any>, elementType: Class<any>): void;
+  abstract define(componentTypeOrName: ComponentClass<any> | string, elementType: Class<any>): void;
 
   /**
    * Allows to wait for component definition.
    *
    * This corresponds to `window.customElements.whenDefined()` method.
    *
-   * @param componentType Component class constructor.
+   * @param componentTypeOrName Component class constructor or custom element name.
    *
-   * @return A promise that is resolved when the given `componentType` is registered.
+   * @return A promise that is resolved when custom element is registered.
    *
    * @throws TypeError If `componentType` does not contain a component definition.
    */
-  abstract whenDefined(componentType: ComponentClass<any>): Promise<void>;
+  abstract whenDefined(componentTypeOrName: ComponentClass<any> | string): Promise<void>;
 
 }

--- a/src/component/definition/element-base-class.key.ts
+++ b/src/component/definition/element-base-class.key.ts
@@ -14,5 +14,5 @@ export const elementBaseClassKey = new SingleContextKey<ElementBaseClass>(
       const componentType = values.get(definitionContextKey).componentType;
       const extend = ComponentDef.of(componentType).extend;
 
-      return extend && extend.type ||  (values.get(BootstrapWindow) as any).HTMLElement;
+      return extend && extend.type || (values.get(BootstrapWindow) as any).HTMLElement;
     });


### PR DESCRIPTION
- Allow anonymous components. Component name can be omitted. Such component is not bound to custom element, but still can be mounted.
- Remove `PartialComponentDef` as it is the same as `ComponentDef` now.
- `CustomElements` can be used to register arbitrary custom elements.