### PR TITLE
Extend `@Attributes()` decorator options

### DIFF
--- a/src/feature/attributes/attributes.decorator.spec.ts
+++ b/src/feature/attributes/attributes.decorator.spec.ts
@@ -26,6 +26,46 @@ describe('feature/attributes/attributes', () => {
 
       expect(updateStateSpy).toHaveBeenCalledWith([attributePathRoot, 'attr'], 'new', 'old');
     });
+    it('updates the state when listed', () => {
+
+      @Component({
+        name: 'test-component',
+        extend: {
+          type: MockElement,
+        }
+      })
+      @Attributes([
+        'attr',
+      ])
+      class TestComponent {
+      }
+
+      const element = new (testElement(TestComponent));
+      const updateStateSpy = jest.spyOn(ComponentContext.of(element), 'updateState');
+
+      element.attributeChangedCallback('attr', 'old', 'new');
+
+      expect(updateStateSpy).toHaveBeenCalledWith([attributePathRoot, 'attr'], 'new', 'old');
+    });
+    it('updates the state when single', () => {
+
+      @Component({
+        name: 'test-component',
+        extend: {
+          type: MockElement,
+        }
+      })
+      @Attributes('attr')
+      class TestComponent {
+      }
+
+      const element = new (testElement(TestComponent));
+      const updateStateSpy = jest.spyOn(ComponentContext.of(element), 'updateState');
+
+      element.attributeChangedCallback('attr', 'old', 'new');
+
+      expect(updateStateSpy).toHaveBeenCalledWith([attributePathRoot, 'attr'], 'new', 'old');
+    });
     it('updates the state with custom function', () => {
 
       const updateSpy = jest.fn();


### PR DESCRIPTION
Accepts string, and array of attribute definition maps and/or strings.