### PR TITLE
Render options

### DIFF
--- a/src/feature/render/render.decorator.spec.ts
+++ b/src/feature/render/render.decorator.spec.ts
@@ -19,11 +19,13 @@ describe('feature/render/render.decorator', () => {
     let testComponent: ComponentClass;
     let renderSpy: Mock;
     let offlineRenderSpy: Mock;
+    let delegateRenderSpy: Mock;
     let definitionContext: DefinitionContext<object>;
 
     beforeEach(() => {
       renderSpy = jest.fn();
       offlineRenderSpy = jest.fn();
+      delegateRenderSpy = jest.fn();
 
       @Component({
         name: 'test-component',
@@ -44,6 +46,11 @@ describe('feature/render/render.decorator', () => {
 
         @DomProperty()
         property = 'value';
+
+        @Render({ offline: true })
+        nestRender() {
+          return delegateRenderSpy;
+        }
 
       }
 
@@ -160,6 +167,30 @@ describe('feature/render/render.decorator', () => {
           connected = false;
           component.property = 'other';
           expect(offlineRenderSpy).toHaveBeenCalled();
+        });
+      });
+
+      describe('Delegated', () => {
+        it('is scheduled', () => {
+          expect(delegateRenderSpy).toHaveBeenCalled();
+        });
+        it('is re-scheduled on state update', () => {
+          component.property = 'other';
+          expect(delegateRenderSpy).toHaveBeenCalledTimes(2);
+        });
+        it('is scheduled with a replacement function', () => {
+
+          const replacement = jest.fn();
+
+          delegateRenderSpy.mockImplementation(() => replacement);
+
+          component.property = 'other';
+          expect(delegateRenderSpy).toHaveBeenCalledTimes(2);
+          expect(replacement).toHaveBeenCalled();
+
+          component.property = 'third';
+          expect(delegateRenderSpy).toHaveBeenCalledTimes(2);
+          expect(replacement).toHaveBeenCalledTimes(2);
         });
       });
     });

--- a/src/feature/render/render.decorator.spec.ts
+++ b/src/feature/render/render.decorator.spec.ts
@@ -1,5 +1,3 @@
-import { noop } from 'call-thru';
-import { EventEmitter, EventProducer } from 'fun-events';
 import { Component, ComponentClass, ComponentContext } from '../../component';
 import { CustomElements, DefinitionContext } from '../../component/definition';
 import { ObjectMock } from '../../spec/mocks';

--- a/src/feature/render/render.decorator.ts
+++ b/src/feature/render/render.decorator.ts
@@ -76,7 +76,7 @@ export namespace Render {
      * When offline rendering is disabled the rendering will be scheduled whenever element is connected.
      *
      * `false` by default. Which means the element contents won't be rendered while disconnected. Rendering will
-     * be initiated once element is connected.
+     * be initiated once element is connected for the first time, or if it is connected after state update.
      */
     offline?: boolean;
 

--- a/src/kit/bootstrap/bootstrap-components.spec.ts
+++ b/src/kit/bootstrap/bootstrap-components.spec.ts
@@ -231,7 +231,10 @@ describe('kit/bootstrap/bootstrap-components', () => {
       });
       it('proxies get() method', () => {
 
-        const spy = jest.spyOn(bootstrapContext, 'get');
+        const spy = jest.fn();
+
+        jest.spyOn(bootstrapContext as any, 'get', 'get').mockImplementation(() => spy);
+
         const someKey = new SingleContextKey<string>('some');
         const opts = { or: 'default' };
 

--- a/src/kit/bootstrap/bootstrap-components.ts
+++ b/src/kit/bootstrap/bootstrap-components.ts
@@ -54,20 +54,28 @@ function initBootstrap(valueRegistry: BootstrapValueRegistry) {
 
   }
 
+  const values = valueRegistry.values;
+
   class BootstrapContext extends BootstrapContext_ {
 
-    readonly onDefinition: EventProducer<[DefinitionContext<any>]>;
-    readonly onComponent: EventProducer<[ComponentContext<any>]>;
-    readonly get = valueRegistry.values.get;
+    get onDefinition() {
+      return elementBuilder.definitions.on;
+    }
+
+    get onComponent() {
+      return elementBuilder.components.on;
+    }
+
+    get get() {
+      return values.get;
+    }
 
     constructor() {
       super();
-      definitionValueRegistry = DefinitionValueRegistry.create(valueRegistry.values);
+      definitionValueRegistry = DefinitionValueRegistry.create(values);
       componentValueRegistry = ComponentValueRegistry.create();
       elementBuilder = ElementBuilder.create({ definitionValueRegistry, componentValueRegistry });
       componentRegistry = ComponentRegistry.create({ bootstrapContext: this, elementBuilder });
-      this.onDefinition = elementBuilder.definitions.on;
-      this.onComponent = elementBuilder.components.on;
       valueRegistry.provide({ a: BootstrapContext, is: this });
       valueRegistry.provide({ a: ComponentKit_, as: ComponentKit });
     }


### PR DESCRIPTION
- Offline rendering option.
  `@Render()`-decorated method no longer schedules rendering for disconnected elements by default.
- Allow to delegate rendering.
  `@Render()`-decorated method may return a function to delegate rendering to.