### PR TITLE
Add element render control (`ElementRenderCtl`)

### DIFF
--- a/src/feature/render/element-render-ctl.impl.ts
+++ b/src/feature/render/element-render-ctl.impl.ts
@@ -1,0 +1,98 @@
+import { noop } from '@proc7ts/call-thru';
+import { EventSupply } from '@proc7ts/fun-events';
+import { immediateRenderScheduler, RenderExecution } from '@proc7ts/render-scheduler';
+import { DefaultRenderScheduler } from '../../boot/globals';
+import { ComponentContext } from '../../component';
+import { ComponentState } from '../state';
+import { ElementRenderCtl } from './element-render-ctl';
+import { ElementRenderer } from './element-renderer';
+import { RenderDef } from './render-def';
+
+/**
+ * @internal
+ */
+const enum RenderStatus {
+  Cancelled = -1,
+  Complete = 0,
+  Pending = 1,
+  Scheduled = 2,
+}
+
+/**
+ * @internal
+ */
+export class ElementRenderCtl$ implements ElementRenderCtl {
+
+  private readonly _renders = new Set<() => void>();
+
+  constructor(private readonly _context: ComponentContext) {
+  }
+
+  renderBy(
+      renderer: ElementRenderer,
+      def: RenderDef = {},
+  ): EventSupply {
+
+    const { path = [] } = def;
+    const stateTracker = this._context.get(ComponentState).track(path);
+    const schedule = this._context.get(DefaultRenderScheduler)();
+
+    let status = RenderStatus.Pending;
+    const supply = stateTracker.onUpdate(() => {
+      if (this._context.connected) {
+        scheduleRenderer();
+      }
+    })
+        .needs(this._context)
+        .whenOff(cancelRenderer);
+
+    this._context.whenConnected(() => {
+      if (status) { // There is a pending update to render.
+        scheduleRenderer();
+      }
+    });
+
+    const immediateSchedule = immediateRenderScheduler();
+
+    this._renders.add(renderNow);
+
+    return supply.whenOff(() => this._renders.delete(renderNow));
+
+    function scheduleRenderer(): void {
+      status = RenderStatus.Scheduled;
+      schedule(renderElement);
+    }
+
+    function renderNow(): void {
+      immediateSchedule(renderElement);
+    }
+
+    function cancelRenderer(): void {
+      if (status === RenderStatus.Scheduled) { // Scheduled, but not rendered yet
+        schedule(noop);
+      }
+      status = RenderStatus.Cancelled;
+    }
+
+    function renderElement(execution: RenderExecution): void {
+      if (status > RenderStatus.Complete) { // Prevent excessive rendering
+        status = RenderStatus.Complete;
+        for (; ;) {
+
+          const newRenderer = renderer(execution);
+
+          if (newRenderer === renderer || typeof newRenderer !== 'function') {
+            break;
+          }
+
+          renderer = newRenderer;
+        }
+      }
+    }
+  }
+
+  renderNow(): void {
+    this._renders.forEach(render => render());
+  }
+
+}

--- a/src/feature/render/element-render-ctl.ts
+++ b/src/feature/render/element-render-ctl.ts
@@ -1,0 +1,59 @@
+/**
+ * @packageDocumentation
+ * @module @wesib/wesib
+ */
+import { ContextRef, SingleContextKey } from '@proc7ts/context-values';
+import { EventSupply } from '@proc7ts/fun-events';
+import { ComponentContext } from '../../component';
+import { ElementRenderCtl$ } from './element-render-ctl.impl';
+import { ElementRenderer } from './element-renderer';
+import { RenderDef } from './render-def';
+
+/**
+ * A render control of component's element.
+ *
+ * Controls rendering by {@link ElementRenderer element renderers}.
+ *
+ * @category Feature
+ */
+export interface ElementRenderCtl {
+
+  /**
+   * Enables component element rendering by the given `renderer`.
+   *
+   * A `renderer` call will be scheduled by [[DefaultRenderScheduler]] once component state updated.
+   *
+   * @param renderer  Element renderer function.
+   * @param def  Optional element rendering definition.
+   *
+   * @returns Render shots supply. Element `renderer` will stop rendering once this supply is cut off.
+   */
+  renderBy(
+      renderer: ElementRenderer,
+      def?: RenderDef,
+  ): EventSupply;
+
+  /**
+   * Executes scheduled element render shots immediately.
+   *
+   * Uses `immediateRenderScheduler` for that.
+   *
+   * Does not execute element renderers that are not scheduled. I.e. if no corresponding state updates happened.
+   */
+  renderNow(): void;
+
+}
+
+/**
+ * A key of component context value containing {@link ElementRenderCtl element render control}.
+ */
+export const ElementRenderCtl: ContextRef<ElementRenderCtl> = (
+    /*#__PURE__*/ new SingleContextKey<ElementRenderCtl>(
+        'element-render-ctl',
+        {
+          byDefault(values) {
+            return new ElementRenderCtl$(values.get(ComponentContext));
+          },
+        },
+    )
+);

--- a/src/feature/render/element-renderer.ts
+++ b/src/feature/render/element-renderer.ts
@@ -2,18 +2,15 @@
  * @packageDocumentation
  * @module @wesib/wesib
  */
-import { noop } from '@proc7ts/call-thru';
 import { RenderExecution } from '@proc7ts/render-scheduler';
-import { DefaultRenderScheduler } from '../../boot/globals';
-import { ComponentContext } from '../../component';
-import { ComponentState } from '../state';
-import { RenderDef } from './render-def';
 
 /**
  * Component's element renderer signature.
  *
  * It has no arguments. It may return either nothing, or a function. In the latter case the returned function will be
  * called immediately to render the element. It may, in turn, return a renderer function, and so on.
+ *
+ * Renderer execution is controlled by {@link ElementRenderCtl element render control}.
  *
  * @category Feature
  */
@@ -27,92 +24,3 @@ export type ElementRenderer =
         this: void,
         execution: RenderExecution,
     ) => void | ElementRenderer;
-
-const enum RenderStatus {
-  Pending,
-  Scheduled,
-  Complete,
-  Cancelled = -1,
-}
-
-/**
- * @category Feature
- */
-export const ElementRenderer = {
-
-  /**
-   * Enables component element rendering.
-   *
-   * A `renderer` function call will be scheduled by [[DefaultRenderScheduler]] once component state updated.
-   *
-   * @param context  Target component context.
-   * @param renderer  Element renderer function.
-   * @param def  Optional element rendering definition.
-   */
-  render(
-      this: void,
-      context: ComponentContext,
-      renderer: ElementRenderer,
-      def: RenderDef = {},
-  ): void {
-
-    const { path = [] } = def;
-    const stateTracker = context.get(ComponentState).track(path);
-    const schedule = context.get(DefaultRenderScheduler)();
-
-    let status = RenderStatus.Pending;
-
-    stateTracker.onUpdate(() => {
-      if (context.connected) {
-        scheduleRenderer();
-      }
-    }).needs(context);
-
-    context.whenConnected(() => {
-      if (status <= 0) { // There is an update to render. Either pending or previously cancelled.
-        scheduleRenderer();
-      }
-    }).whenOff(() => {
-      // Component destroyed
-      cancelRenderer();
-    });
-
-    function scheduleRenderer(): void {
-      status = RenderStatus.Scheduled;
-      schedule(renderElement);
-    }
-
-    function cancelRenderer(): void {
-      if (status === RenderStatus.Scheduled) { // Scheduled, but not rendered yet
-        schedule(noop);
-        status = RenderStatus.Cancelled;
-      }
-    }
-
-    function renderElement(execution: RenderExecution): void {
-      /* istanbul ignore next */
-      if (status < 0) {
-        // Prevent cancelled rendering
-
-        /*
-        Should never happen since render-scheduler v1.1
-        As disconnecting in another schedule would correctly cancel this one,
-        because it is not executed yet and thus will be replaced by `noop`.
-        */
-        return;
-      }
-      status = RenderStatus.Complete;
-      for (;;) {
-
-        const newRenderer = renderer(execution);
-
-        if (newRenderer === renderer || typeof newRenderer !== 'function') {
-          break;
-        }
-
-        renderer = newRenderer;
-      }
-    }
-  },
-
-};

--- a/src/feature/render/index.ts
+++ b/src/feature/render/index.ts
@@ -1,3 +1,4 @@
+export * from './element-render-ctl';
 export * from './element-renderer';
 export * from './render.decorator';
 export * from './render-def';

--- a/src/feature/render/render.decorator.spec.ts
+++ b/src/feature/render/render.decorator.spec.ts
@@ -1,6 +1,7 @@
 import {
   immediateRenderScheduler,
   newManualRenderScheduler,
+  noopRenderScheduler,
   RenderSchedule,
   RenderScheduleOptions,
   RenderScheduler,
@@ -10,6 +11,7 @@ import { Component, ComponentContext } from '../../component';
 import { MockElement, testElement } from '../../spec/test-element';
 import { DomProperty, domPropertyPathTo } from '../dom-properties';
 import { ComponentState } from '../state';
+import { ElementRenderCtl } from './element-render-ctl';
 import { ElementRenderer } from './element-renderer';
 import { RenderDef } from './render-def';
 import { Render } from './render.decorator';
@@ -191,6 +193,43 @@ describe('feature/render', () => {
         component.property = 'third';
         expect(mockRenderer).toHaveBeenCalledTimes(2);
         expect(replacement).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('ElementRenderCtl', () => {
+      beforeEach(() => {
+        mockRenderSchedule.mockImplementation(noopRenderScheduler());
+      });
+
+      describe('renderNow', () => {
+        it('renders component immediately', async () => {
+
+          const context = await bootstrap();
+          const renderCtl = context.get(ElementRenderCtl);
+
+          renderCtl.renderNow();
+          expect(mockRenderer).toHaveBeenCalledTimes(1);
+        });
+        it('does not render component without state update', async () => {
+
+          const context = await bootstrap();
+          const renderCtl = context.get(ElementRenderCtl);
+
+          renderCtl.renderNow();
+          renderCtl.renderNow();
+          renderCtl.renderNow();
+          expect(mockRenderer).toHaveBeenCalledTimes(1);
+        });
+        it('renders component after state update', async () => {
+
+          const context = await bootstrap();
+          const renderCtl = context.get(ElementRenderCtl);
+
+          renderCtl.renderNow();
+          context.element.property = 'other';
+          renderCtl.renderNow();
+          expect(mockRenderer).toHaveBeenCalledTimes(2);
+        });
       });
     });
 

--- a/src/feature/render/render.decorator.ts
+++ b/src/feature/render/render.decorator.ts
@@ -6,6 +6,7 @@ import { RenderExecution } from '@proc7ts/render-scheduler';
 import { ComponentProperty, ComponentPropertyDecorator } from '../../component';
 import { ComponentClass } from '../../component/definition';
 import { StateSupport } from '../state';
+import { ElementRenderCtl } from './element-render-ctl';
 import { ElementRenderer } from './element-renderer';
 import { RenderDef } from './render-def';
 
@@ -20,7 +21,7 @@ import { RenderDef } from './render-def';
  *
  * This decorator automatically enables [[StateSupport]] feature.
  *
- * Utilizes [[ElementRenderer.render]] function to enable rendering.
+ * Enables rendering with {@link ElementRenderCtl.renderBy element render control}.
  *
  * @category Feature
  * @typeparam T  A type of decorated component class.
@@ -41,8 +42,9 @@ export function Render<T extends ComponentClass>(
           context.whenReady(() => {
 
             const { component } = context;
+            const renderer = get(component).bind(component);
 
-            ElementRenderer.render(context, get(component).bind(component), def);
+            context.get(ElementRenderCtl).renderBy(renderer, def);
           });
         });
       },


### PR DESCRIPTION
Controls element rendering. Allows immediate element rendering.

Drop `ElementRenderer.render()` static method in favor of `ElementRenderCtl.renderBy()`.