### PR TITLE
Elements naming

### DIFF
--- a/src/boot/impl/definition-context.impl.ts
+++ b/src/boot/impl/definition-context.impl.ts
@@ -3,7 +3,7 @@ import { mapOn_, onceOn, OnEvent, trackValue, translateOn, ValueTracker } from '
 import { Class, valueProvider } from '@proc7ts/primitives';
 import { Supply } from '@proc7ts/supply';
 import { ComponentContext, ComponentDef, ComponentElement, ComponentSlot } from '../../component';
-import { DefinitionContext, DefinitionSetup } from '../../component/definition';
+import { DefinitionContext, DefinitionSetup, ElementDef, ElementNaming } from '../../component/definition';
 import { BootstrapContext } from '../bootstrap-context';
 import { DocumentRenderKit } from '../globals';
 import { ComponentContextRegistry, PerComponentRegistry } from './component-context-registry.impl';
@@ -22,6 +22,7 @@ export class DefinitionContext$<T extends object> extends DefinitionContext<T> {
 
   readonly whenReady: OnEvent<[this]>;
   readonly get: ContextValues['get'];
+  readonly elementDef: ElementDef;
   private readonly _def: ComponentDef<T>;
   readonly _whenComponent = new WhenComponent<T>();
   private readonly _ready: ValueTracker<boolean>;
@@ -37,6 +38,7 @@ export class DefinitionContext$<T extends object> extends DefinitionContext<T> {
     this._ready = trackValue(false);
     this._whenReady = this._ready.read.do(translateOn((send, ready) => ready && send()));
     this._def = ComponentDef.of(componentType);
+    this.elementDef = _bsContext.get(ElementNaming).elementOf(componentType);
 
     const definitionContextRegistry = new DefinitionContextRegistry(_bsContext.get(PerDefinitionRegistry).seeds());
 

--- a/src/component/definition/definition-context.ts
+++ b/src/component/definition/definition-context.ts
@@ -43,9 +43,7 @@ export abstract class DefinitionContext<T extends object = any> extends ContextV
   /**
    * Custom element definition.
    */
-  get elementDef(): ElementDef {
-    return this.get(ElementDef);
-  }
+  abstract readonly elementDef: ElementDef;
 
   /**
    * An `OnEvent` sender of component definition context upon its readiness.

--- a/src/component/definition/element-def.ts
+++ b/src/component/definition/element-def.ts
@@ -1,9 +1,8 @@
-import { html__naming, QualifiedName } from '@frontmeans/namespace-aliaser';
+import { QualifiedName } from '@frontmeans/namespace-aliaser';
 import { SingleContextKey, SingleContextRef } from '@proc7ts/context-values';
 import { Class } from '@proc7ts/primitives';
-import { BootstrapWindow, DefaultNamespaceAliaser } from '../../boot/globals';
-import { ComponentDef } from '../component-def';
 import { DefinitionContext__key } from './definition.context.key.impl';
+import { ElementNaming } from './element-naming';
 
 /**
  * Custom element definition meta.
@@ -49,31 +48,7 @@ export const ElementDef: SingleContextRef<ElementDef> = (/*#__PURE__*/ new Singl
     'element-def',
     {
       byDefault(values) {
-
-        const componentType = values.get(DefinitionContext__key).componentType;
-        const { name, extend } = ComponentDef.of(componentType);
-        let tagName: string | undefined;
-
-        const elementExtend: ElementDef.Extend = {
-          get type() {
-            return extend && extend.type || values.get(BootstrapWindow).HTMLElement;
-          },
-          get name() {
-            return extend && extend.name;
-          },
-        };
-
-        return {
-          get name() {
-            return name;
-          },
-          get tagName() {
-            return tagName || (name && (tagName = html__naming.name(name, values.get(DefaultNamespaceAliaser))));
-          },
-          get extend() {
-            return elementExtend;
-          },
-        };
+        return values.get(ElementNaming).elementOf(values.get(DefinitionContext__key).componentType);
       },
     },
 ));

--- a/src/component/definition/element-def.ts
+++ b/src/component/definition/element-def.ts
@@ -1,8 +1,5 @@
 import { QualifiedName } from '@frontmeans/namespace-aliaser';
-import { SingleContextKey, SingleContextRef } from '@proc7ts/context-values';
 import { Class } from '@proc7ts/primitives';
-import { DefinitionContext__key } from './definition.context.key.impl';
-import { ElementNaming } from './element-naming';
 
 /**
  * Custom element definition meta.
@@ -35,23 +32,6 @@ export interface ElementDef {
   readonly extend: ElementDef.Extend;
 
 }
-
-/**
- * A key of definition context value containing a custom element definition.
- *
- * Target value defaults to `HTMLElement` from the window provided under `[BootstrapWindow.key]`,
- * unless `ComponentDef.extend.type` is specified.
- *
- * @category Core
- */
-export const ElementDef: SingleContextRef<ElementDef> = (/*#__PURE__*/ new SingleContextKey<ElementDef>(
-    'element-def',
-    {
-      byDefault(values) {
-        return values.get(ElementNaming).elementOf(values.get(DefinitionContext__key).componentType);
-      },
-    },
-));
 
 /**
  * @category Core

--- a/src/component/definition/element-naming.ts
+++ b/src/component/definition/element-naming.ts
@@ -1,0 +1,68 @@
+import { html__naming } from '@frontmeans/namespace-aliaser';
+import { ContextKey, SingleContextKey } from '@proc7ts/context-values';
+import { BootstrapContext, bootstrapDefault } from '../../boot';
+import { BootstrapWindow, DefaultNamespaceAliaser } from '../../boot/globals';
+import { ComponentDef } from '../component-def';
+import { ComponentClass } from './component-class';
+import { ElementDef } from './element-def';
+
+/**
+ * Component element naming service.
+ */
+export interface ElementNaming {
+
+  /**
+   * Obtains element definition of the given component.
+   *
+   * @param componentType - Target component class.
+   *
+   * @returns Element definition meta.
+   */
+  elementOf(componentType: ComponentClass): ElementDef;
+
+}
+
+/**
+ * A key of bootstrap context value containing an element naming service instance.
+ */
+export const ElementNaming: ContextKey<ElementNaming> = (/*#__PURE__*/ new SingleContextKey<ElementNaming>(
+    'element-naming',
+    {
+      byDefault: bootstrapDefault(newElementNaming),
+    },
+));
+
+function newElementNaming(bsContext: BootstrapContext): ElementNaming {
+
+  const bsWindow = bsContext.get(BootstrapWindow);
+  const nsAlias = bsContext.get(DefaultNamespaceAliaser);
+
+  return {
+    elementOf(componentType: ComponentClass): ElementDef {
+
+      const { name, extend } = ComponentDef.of(componentType);
+      let tagName: string | undefined;
+
+      const elementExtend: ElementDef.Extend = {
+        get type() {
+          return extend && extend.type || bsWindow.HTMLElement;
+        },
+        get name() {
+          return extend && extend.name;
+        },
+      };
+
+      return {
+        get name() {
+          return name;
+        },
+        get tagName() {
+          return tagName || (name && (tagName = html__naming.name(name, nsAlias)));
+        },
+        get extend() {
+          return elementExtend;
+        },
+      };
+    },
+  };
+}

--- a/src/component/definition/index.ts
+++ b/src/component/definition/index.ts
@@ -3,3 +3,4 @@ export * from './custom-elements';
 export * from './definition-context';
 export * from './definition-setup';
 export * from './element-def';
+export * from './element-naming';


### PR DESCRIPTION
- Introduce `ElementNaming` service
- `ElementDef` is no longer a definition context value
